### PR TITLE
feat(KFLUXVNGD-387): Ensure all Squid logs go to STDOUT

### DIFF
--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -1,0 +1,69 @@
+# Cursor Configuration
+
+This directory contains Cursor-specific configuration for AI-assisted development.
+
+## How Cursor @ Mentions Work
+
+Cursor's @ system references files and rules directly. You only need these two simple commands:
+
+### 🎯 Commit Message Generation
+```
+@commit-messages.mdc Generate a commit message for my staged changes
+```
+
+### 🌿 Branch Creation  
+```
+@branch-creation.mdc Create a branch for Jira issue KFLUXVNGD-358
+```
+
+## File Structure
+
+```
+.cursor/
+├── README.md              # This file
+└── rules/
+    ├── commit-messages.mdc # Commit message formatting rules
+    └── branch-creation.mdc # Branch creation from Jira issues
+```
+
+**That's it!** No extra directories or files cluttering your @ completions.
+
+## Usage Tips
+
+### @ Mentions Explained
+- `@commit-messages.mdc` - References your commit formatting rules
+- `@branch-creation.mdc` - References your branch creation rules
+- These `.mdc` files contain all the logic and are automatically applied
+- No other files are needed!
+
+### Environment Setup
+Your dev container is configured with:
+- `GIT_AUTHOR_NAME` and `GIT_AUTHOR_EMAIL` environment variables
+- These are automatically used in commit message footers
+
+## Examples
+
+### Generate a commit message:
+```
+@commit-messages.mdc Generate a commit message
+```
+
+### Create a new branch:
+```
+@branch-creation.mdc Create a branch for KFLUXVNGD-123
+```
+
+### Get help (without @):
+```
+What's the proper format for commit messages in this project?
+```
+(The AI will reference your rules automatically)
+
+## Integration
+
+These configurations work with:
+- ✅ VS Code/Cursor editor settings (line length, rulers)
+- ✅ Git environment variables (author info)  
+- ✅ Conventional commits standard
+- ✅ Jira issue integration
+- ✅ issues.redhat.com lookup 

--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,7 @@
+{
+    "mcpServers": {
+        "jira-mcp-server": {
+            "url": "https://jira-mcp-snowflake.mcp-playground-poc.devshift.net/sse"
+        }
+    }
+}

--- a/.cursor/rules/branch-creation.mdc
+++ b/.cursor/rules/branch-creation.mdc
@@ -1,0 +1,184 @@
+---
+description: Branch Creation Process, to apply when user is asking for branch cretion from Jira info
+alwaysApply: false
+---
+# Branch Creation from Jira Issues
+
+**When to apply**: When creating new branches based on Jira issues
+
+**Description**: Rules for creating properly named branches from Jira issue information
+
+## Prerequisites
+
+### 1. Jira Token Setup
+Before creating branches, set up authentication:
+
+```bash
+# Create token file (only once)
+echo "your_personal_access_token_here" > .jira-token
+```
+
+**Security Notes:**
+- Never commit `.jira-token` to version control (already in `.gitignore`)
+- Revoke and regenerate tokens if exposed
+- Use personal access tokens from Jira settings
+
+## Branch Creation Process
+
+### 1. Get Jira Issue Number
+- Ask user for the Jira issue number (e.g., "KFLUXVNGD-387")
+- Validate format matches pattern: `[A-Z]{2,}-[0-9]+`
+
+### 2. Fetch Issue Details from API
+Use Red Hat Jira API v2 with Bearer token authentication:
+
+```bash
+# Fetch issue details
+TOKEN=$(cat .jira-token)
+curl -s -H "Authorization: Bearer $TOKEN" \
+     -H "Accept: application/json" \
+     "https://issues.redhat.com/rest/api/2/issue/KFLUXVNGD-387"
+
+# Extract summary
+curl -s -H "Authorization: Bearer $TOKEN" \
+     -H "Accept: application/json" \
+     "https://issues.redhat.com/rest/api/2/issue/KFLUXVNGD-387" | \
+     grep -o '"summary":"[^"]*"' | cut -d'"' -f4
+
+# Extract issue type
+curl -s -H "Authorization: Bearer $TOKEN" \
+     -H "Accept: application/json" \
+     "https://issues.redhat.com/rest/api/2/issue/KFLUXVNGD-387" | \
+     grep -o '"issuetype":{"[^}]*"name":"[^"]*"' | cut -d'"' -f8
+```
+
+### 3. Generate Branch Name
+- Format: `{JIRA-ID}-{short-description}`
+- Convert summary to kebab-case
+- **Limit to 30 characters total** (user preference)
+- Remove special characters and spaces
+- Prioritize issue key + meaningful keywords
+
+## Branch Naming Convention
+
+**30-character limit examples:**
+```
+KFLUXVNGD-387-squid-logs-stdout  (30 chars)
+KFLUXVNGD-358-helm-chart-design  (30 chars)
+KFLUXVNGD-359-fix-auth-timeout   (29 chars)
+```
+
+## Branch Creation Commands
+
+### Local Branch Only
+```bash
+# Create and switch to new branch
+git checkout -b {branch-name}
+```
+
+### With Remote Push
+```bash
+# Create and switch to new branch
+git checkout -b {branch-name}
+
+# Push new branch to origin (after commits)
+git push -u origin {branch-name}
+```
+
+## Issue Type Mapping
+
+Use direct issue number format for all types:
+- **Bug**: Direct issue number (no prefix)
+- **Story**: Direct issue number (no prefix)
+- **Task**: Direct issue number (no prefix)
+- **Epic**: Direct issue number (no prefix)
+
+## Working Example
+
+### Successful Process (KFLUXVNGD-387)
+
+```bash
+# 1. Fetch issue details
+TOKEN=$(cat .jira-token)
+SUMMARY=$(curl -s -H "Authorization: Bearer $TOKEN" \
+               -H "Accept: application/json" \
+               "https://issues.redhat.com/rest/api/2/issue/KFLUXVNGD-387" | \
+          grep -o '"summary":"[^"]*"' | cut -d'"' -f4)
+
+# 2. Issue details retrieved:
+# Summary: "Task 1.1.5: Ensure all Squid logs go to STDOUT"
+# Type: Task
+
+# 3. Generated branch name (30 chars):
+# KFLUXVNGD-387-squid-logs-stdout
+
+# 4. Create branch
+git checkout -b KFLUXVNGD-387-squid-logs-stdout
+```
+
+## API Requirements
+
+### Working Configuration
+- **Base URL**: `https://issues.redhat.com`
+- **API Version**: `/rest/api/2/` (v2, not v3)
+- **Authentication**: `Authorization: Bearer {token}`
+- **Content Type**: `Accept: application/json`
+
+### Authentication Method
+```bash
+# Bearer token (WORKING)
+curl -H "Authorization: Bearer $TOKEN" \
+     -H "Accept: application/json" \
+     "https://issues.redhat.com/rest/api/2/issue/{ISSUE-KEY}"
+
+# Basic auth (NOT WORKING with Red Hat Jira)
+# curl -u "email:token" (returns 401)
+```
+
+## Troubleshooting
+
+### API Access Issues
+1. **401 Unauthorized**:
+   - Check token validity in Jira settings
+   - Verify using API v2 (not v3)
+   - Ensure Bearer token format
+
+2. **No Response/Hanging**:
+   - Add timeouts: `--connect-timeout 10 --max-time 30`
+   - Check network connectivity
+   - Verify Jira URL accessibility
+
+3. **Token Exposure**:
+   - Revoke exposed token immediately
+   - Generate new token
+   - Update `.jira-token` file
+   - Verify `.gitignore` includes `.jira-token`
+
+### Branch Name Issues
+1. **Too Long**: Abbreviate description parts
+2. **Special Characters**: Convert to kebab-case
+3. **Unclear**: Include key meaningful words from summary
+
+## Integration with Commit Messages
+
+After creating branch, remind user that:
+- Commit messages will automatically include the Jira issue in scope
+- The commit-messages.mdc rule will handle formatting
+- First commit should reference the issue details
+
+## Security Best Practices
+
+1. **Token Management**:
+   - Store in `.jira-token` file (gitignored)
+   - Use personal access tokens (not passwords)
+   - Rotate tokens regularly
+   - Revoke immediately if exposed
+
+2. **Version Control**:
+   - Always gitignore token files
+   - Never commit authentication credentials
+   - Use environment variables in CI/CD
+
+## File Pattern Matching
+
+Apply to: `**/*` (all files when discussing branch creation)

--- a/.cursor/rules/commit-messages.mdc
+++ b/.cursor/rules/commit-messages.mdc
@@ -1,0 +1,140 @@
+---
+description: Git commit message formatting rules, for use when generating commit messages
+alwaysApply: false
+---
+# Commit Message Formatting Rules
+
+**When to apply**: When generating commit messages or discussing commit practices
+
+**Description**: Rules for formatting commit messages with conventional commits and Jira issue integration
+
+## Commit Message Format
+
+Use conventional commits format:
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+Signed-off-by: <name> <email>
+Assisted-by: <model-name> (via Cursor)
+```
+
+## Line Length Requirements
+
+Follow conventional commit line length standards:
+- **Subject line**: Maximum 50 characters (hard limit: 72 characters)
+- **Body**: Wrap at 72 characters per line
+- **Blank line**: Always include blank line between subject and body
+- **Footer**: Each footer on separate line
+
+## Scope Rules
+
+1. **For branches with Jira issues** (pattern: `KFLUXVNGD-XXX-description`):
+   - Extract Jira issue number using regex: `[A-Z]{2,}-[0-9]+`
+   - Use as scope: `feat(KFLUXVNGD-358): description`
+
+2. **For main/master branches or non-Jira branches**:
+   - Ask user for Jira issue number
+   - Look up issue on issues.redhat.com using web search
+   - Use component name as fallback: `feat(squid)`, `fix(helm)`, `docs(README)`
+
+## Commit Types
+
+- **feat**: New features
+- **fix**: Bug fixes  
+- **docs**: Documentation changes
+- **style**: Code style changes
+- **refactor**: Code refactoring
+- **test**: Adding/updating tests
+- **chore**: Maintenance tasks
+- **build**: Build system or dependencies
+- **ci**: CI/CD changes
+- **perf**: Performance improvements
+- **revert**: Revert previous commit
+
+## Required Footers
+
+### Signed-off-by
+- Always include: `Signed-off-by: <name> <email>`
+- Get name and email using this priority order:
+  1. Environment variables: `$GIT_AUTHOR_NAME` and `$GIT_AUTHOR_EMAIL`
+  2. Git config: `git config user.name` and `git config user.email`
+  3. If neither configured, ask user to provide details
+- Common in dev containers: environment variables are preferred method
+
+### Assisted-by
+- Always include: `Assisted-by: <model-name> (via Cursor)`
+- Format examples:
+  - `Assisted-by: Claude-3.5-Sonnet (via Cursor)`
+  - `Assisted-by: Gemini (via Cursor)`
+- Use the actual model name being used for the commit message generation
+
+## Examples
+
+```bash
+feat(KFLUXVNGD-358): Add Helm chart and configuration for Squid proxy
+
+Signed-off-by: Barak Korren <bkorren@redhat.com>
+Assisted-by: Claude-3.5-Sonnet (via Cursor)
+```
+
+```bash
+fix(squid): Update proxy configuration settings
+
+Resolves issue with authentication timeout
+
+Signed-off-by: Barak Korren <bkorren@redhat.com>
+Assisted-by: Claude-3.5-Sonnet (via Cursor)
+```
+
+## Auto-Detection Rules
+
+When generating commit messages:
+1. Check current branch name for Jira issue pattern
+2. If no Jira issue in branch, ask user for issue number
+3. Look up issue details on issues.redhat.com if provided
+4. Analyze staged files to determine commit type
+5. Generate appropriate scope and description
+6. Detect author info from environment variables ($GIT_AUTHOR_NAME, $GIT_AUTHOR_EMAIL) or git config
+7. Ensure subject line is ≤50 characters (max 72 characters)
+8. Wrap body text at 72 characters per line
+9. Add required footers (Signed-off-by and Assisted-by)
+10. Format according to conventional commits standard
+
+## Commit Process
+
+**IMPORTANT**: Always ask for user confirmation before executing `git commit`:
+
+1. **Generate** the commit message following the rules above
+2. **Display** the generated commit message to the user
+3. **Ask for confirmation**: "Should I commit with this message? (y/n)"
+4. **Wait for user response** before running `git commit`
+5. **Only commit** if user confirms with "yes", "y", or similar affirmative response
+
+**Example interaction:**
+```
+Generated commit message:
+---
+feat(KFLUXVNGD-387): ensure squid logs output to stdout
+
+Configure squid.conf to direct all logs to stdout for container compatibility
+
+Signed-off-by: Barak Korren <bkorren@redhat.com>
+Assisted-by: Claude-3.5-Sonnet (via Cursor)
+---
+
+Should I commit with this message? (y/n)
+```
+
+## Jira Issue Lookup Process
+
+When no Jira issue is found in branch name:
+1. Ask user: "What Jira issue number should I use for this commit?"
+2. If provided, search issues.redhat.com for issue details
+3. Use issue summary and description to enhance commit message
+4. Suggest creating a new branch if desired (refer to branch-creation.mdc rule)
+
+## File Pattern Matching
+
+Apply to: `**/*` (all files when discussing commits)

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ go.work.sum
 # env file
 .env
 
+# Jira token
+.jira-token
+
 # Editor/IDE
 # .idea/
 # .vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,30 @@
+{
+    "git.inputValidation": true,
+    "git.inputValidationLength": 72,
+    "git.inputValidationSubjectLength": 50,
+    "git.verboseCommit": true,
+    "editor.rulers": [
+        80,
+        100
+    ],
+    "editor.wordWrap": "off",
+    "editor.wordWrapColumn": 100,
+    "[git-commit]": {
+        "editor.rulers": [
+            50,
+            72
+        ],
+        "editor.wordWrap": "wordWrapColumn",
+        "editor.wordWrapColumn": 72,
+        "editor.insertSpaces": true,
+        "editor.tabSize": 2
+    },
+    "[scm-input]": {
+        "editor.rulers": [
+            50,
+            72
+        ],
+        "editor.wordWrap": "wordWrapColumn",
+        "editor.wordWrapColumn": 72
+    }
+}

--- a/squid/squid.conf
+++ b/squid/squid.conf
@@ -77,13 +77,18 @@ http_port 3128
 # Uncomment and adjust the following to add a disk cache directory.
 #cache_dir ufs /var/spool/squid 100 16 256
 
-# Leave coredumps in the first cache dir
-coredump_dir /var/spool/squid
+# Logging configuration - separate streams by purpose
+# access_log -> STDOUT: HTTP request data (application logs)
+# cache_log -> STDERR: operational/administrative messages (startup, config, errors, debug)
+access_log stdio:/dev/stdout squid
+cache_log /dev/stderr
+
+# Disable core dumps
+coredump_dir none
 
 #
 # Add any of your own refresh_pattern entries above these.
 #
 refresh_pattern ^ftp:           1440    20%     10080
 refresh_pattern -i (/cgi-bin/|\?) 0     0%      0
-refresh_pattern .               0       20%     4320
-pid_filename /run/squid/squid.pid 
+refresh_pattern .               0       20%     4320 


### PR DESCRIPTION
Configures Squid to output all logs to STDOUT/STDERR instead of file-based logging for better container compatibility.

## Changes
- **squid.conf**: 
  - Direct `access_log` to `stdio:/dev/stdout` (HTTP request logs)
  - Direct `cache_log` to `/dev/stderr` (operational/admin logs)
  - Disable core dumps (`coredump_dir none`)
  - Remove file-based logging configuration

- **Development workflow** (bonus):
  - Add Cursor rules for Jira-integrated commit messages
  - Add branch creation rules with Red Hat Jira API integration
  - Configure token security and gitignore