### PR TITLE
feat(KFLUXVNGD-365): trust-manager integration for CA trust bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,36 @@ kubectl get pods -n proxy
 kubectl get svc -n proxy
 ```
 
-By default, the cert-manager dependency will be deployed into the cert-manager namespace. 
-If you wish to disable this deployment, you can do so by setting the parameter `--set cert-manager.enabled=false`
+By default: 
+- The cert-manager and trust-manager dependencies will be deployed into the cert-manager namespace. 
+If you wish to disable these deployments, you can do so by setting the parameter `--set installCertManagerComponents=false`
 
-```bash
-# Install the Helm chart without cert-manager
-helm install squid ./squid --set cert-manager.enabled=false
-```
+- The resources (issuer, certificate, bundle) are created
+if you wish to disable the resources creation, you can do so by setting the parameter `--set selfsigned-bundle.enabled=false`
+
+#### Examples:
+
+  ```bash
+  # Install squid + cert-manager + trust-manager + resources
+  helm install squid ./squid
+  ```
+
+  ```bash
+  # Install squid without cert-manager, without trust-manager and without creating resources
+  helm install squid ./squid --set installCertManagerComponents=false --set selfsigned-bundle.enabled=false
+  ```
+
+  ```bash
+  # Install squid + cert-manager + trust-manager without creating resources
+  helm install squid ./squid --set selfsigned-issuer.enabled=false
+  ```
+
+  ```bash
+  # Install squid without cert-manager, without trust-manager + create resources
+  helm install squid ./squid --set installCertManagerComponents=false
+  ```
+  
+
 
 ## Using the Proxy
 

--- a/squid/Chart.yaml
+++ b/squid/Chart.yaml
@@ -28,8 +28,8 @@ dependencies:
   - name: cert-manager
     version: v1.18.0
     repository: https://charts.jetstack.io
-    condition: cert-manager.enabled
+    condition: installCertManagerComponents
   - name: trust-manager
     version: v0.18.0
     repository: https://charts.jetstack.io
-    condition: cert-manager.enabled
+    condition: installCertManagerComponents

--- a/squid/crds/trust.cert-manager.io_bundles.yaml
+++ b/squid/crds/trust.cert-manager.io_bundles.yaml
@@ -1,0 +1,495 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: bundles.trust.cert-manager.io
+spec:
+  group: trust.cert-manager.io
+  names:
+    kind: Bundle
+    listKind: BundleList
+    plural: bundles
+    singular: bundle
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Bundle ConfigMap Target Key
+      jsonPath: .spec.target.configMap.key
+      name: ConfigMap Target
+      type: string
+    - description: Bundle Secret Target Key
+      jsonPath: .spec.target.secret.key
+      name: Secret Target
+      type: string
+    - description: Bundle has been synced
+      jsonPath: .status.conditions[?(@.type == "Synced")].status
+      name: Synced
+      type: string
+    - description: Reason Bundle has Synced status
+      jsonPath: .status.conditions[?(@.type == "Synced")].reason
+      name: Reason
+      type: string
+    - description: Timestamp Bundle was created
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: Desired state of the Bundle resource.
+            properties:
+              sources:
+                description: Sources is a set of references to data whose data will
+                  sync to the target.
+                items:
+                  description: |-
+                    BundleSource is the set of sources whose data will be appended and synced to
+                    the BundleTarget in all Namespaces.
+                  properties:
+                    configMap:
+                      description: |-
+                        ConfigMap is a reference (by name) to a ConfigMap's `data` key(s), or to a
+                        list of ConfigMap's `data` key(s) using label selector, in the trust Namespace.
+                      properties:
+                        includeAllKeys:
+                          description: |-
+                            IncludeAllKeys is a flag to include all keys in the object's `data` field to be used. False by default.
+                            This field must not be true when `Key` is set.
+                          type: boolean
+                        key:
+                          description: Key of the entry in the object's `data` field
+                            to be used.
+                          minLength: 1
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the source object in the trust Namespace.
+                            This field must be left empty when `selector` is set
+                          minLength: 1
+                          type: string
+                        selector:
+                          description: |-
+                            Selector is the label selector to use to fetch a list of objects. Must not be set
+                            when `Name` is set.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    inLine:
+                      description: InLine is a simple string to append as the source
+                        data.
+                      type: string
+                    secret:
+                      description: |-
+                        Secret is a reference (by name) to a Secret's `data` key(s), or to a
+                        list of Secret's `data` key(s) using label selector, in the trust Namespace.
+                      properties:
+                        includeAllKeys:
+                          description: |-
+                            IncludeAllKeys is a flag to include all keys in the object's `data` field to be used. False by default.
+                            This field must not be true when `Key` is set.
+                          type: boolean
+                        key:
+                          description: Key of the entry in the object's `data` field
+                            to be used.
+                          minLength: 1
+                          type: string
+                        name:
+                          description: |-
+                            Name is the name of the source object in the trust Namespace.
+                            This field must be left empty when `selector` is set
+                          minLength: 1
+                          type: string
+                        selector:
+                          description: |-
+                            Selector is the label selector to use to fetch a list of objects. Must not be set
+                            when `Name` is set.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    useDefaultCAs:
+                      description: |-
+                        UseDefaultCAs, when true, requests the default CA bundle to be used as a source.
+                        Default CAs are available if trust-manager was installed via Helm
+                        or was otherwise set up to include a package-injecting init container by using the
+                        "--default-package-location" flag when starting the trust-manager controller.
+                        If default CAs were not configured at start-up, any request to use the default
+                        CAs will fail.
+                        The version of the default CA package which is used for a Bundle is stored in the
+                        defaultCAPackageVersion field of the Bundle's status field.
+                      type: boolean
+                  type: object
+                  x-kubernetes-map-type: atomic
+                maxItems: 100
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+              target:
+                description: Target is the target location in all namespaces to sync
+                  source data to.
+                properties:
+                  additionalFormats:
+                    description: AdditionalFormats specifies any additional formats
+                      to write to the target
+                    properties:
+                      jks:
+                        description: |-
+                          JKS requests a JKS-formatted binary trust bundle to be written to the target.
+                          The bundle has "changeit" as the default password.
+                          For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
+                          Deprecated: Writing JKS is subject for removal. Please migrate to PKCS12.
+                          PKCS#12 trust stores created by trust-manager are compatible with Java.
+                        properties:
+                          key:
+                            description: Key is the key of the entry in the object's
+                              `data` field to be used.
+                            minLength: 1
+                            type: string
+                          password:
+                            default: changeit
+                            description: Password for JKS trust store
+                            maxLength: 128
+                            minLength: 1
+                            type: string
+                        required:
+                        - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      pkcs12:
+                        description: |-
+                          PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the target.
+
+                          The bundle is by default created without a password.
+                          For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
+                        properties:
+                          key:
+                            description: Key is the key of the entry in the object's
+                              `data` field to be used.
+                            minLength: 1
+                            type: string
+                          password:
+                            default: ""
+                            description: Password for PKCS12 trust store
+                            maxLength: 128
+                            type: string
+                          profile:
+                            description: |-
+                              Profile specifies the certificate encryption algorithms and the HMAC algorithm
+                              used to create the PKCS12 trust store.
+
+                              If provided, allowed values are:
+                              `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
+                              `LegacyDES`: Less secure algorithm. Use this option for maximal compatibility.
+                              `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms (e.g. because of company policy).
+
+                              Default value is `LegacyRC2` for backward compatibility.
+                            enum:
+                            - LegacyRC2
+                            - LegacyDES
+                            - Modern2023
+                            type: string
+                        required:
+                        - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  configMap:
+                    description: |-
+                      ConfigMap is the target ConfigMap in Namespaces that all Bundle source
+                      data will be synced to.
+                    properties:
+                      key:
+                        description: Key is the key of the entry in the object's `data`
+                          field to be used.
+                        minLength: 1
+                        type: string
+                      metadata:
+                        description: Metadata is an optional set of labels and annotations
+                          to be copied to the target.
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations is a key value map to be copied
+                              to the target.
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: Labels is a key value map to be copied to
+                              the target.
+                            type: object
+                        type: object
+                    required:
+                    - key
+                    type: object
+                  namespaceSelector:
+                    description: |-
+                      NamespaceSelector will, if set, only sync the target resource in
+                      Namespaces which match the selector.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  secret:
+                    description: |-
+                      Secret is the target Secret that all Bundle source data will be synced to.
+                      Using Secrets as targets is only supported if enabled at trust-manager startup.
+                      By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.
+                    properties:
+                      key:
+                        description: Key is the key of the entry in the object's `data`
+                          field to be used.
+                        minLength: 1
+                        type: string
+                      metadata:
+                        description: Metadata is an optional set of labels and annotations
+                          to be copied to the target.
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations is a key value map to be copied
+                              to the target.
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: Labels is a key value map to be copied to
+                              the target.
+                            type: object
+                        type: object
+                    required:
+                    - key
+                    type: object
+                type: object
+            required:
+            - sources
+            - target
+            type: object
+          status:
+            description: Status of the Bundle. This is set and managed automatically.
+            properties:
+              conditions:
+                description: |-
+                  List of status conditions to indicate the status of the Bundle.
+                  Known condition types are `Bundle`.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              defaultCAVersion:
+                description: |-
+                  DefaultCAPackageVersion, if set and non-empty, indicates the version information
+                  which was retrieved when the set of default CAs was requested in the bundle
+                  source. This should only be set if useDefaultCAs was set to "true" on a source,
+                  and will be the same for the same version of a bundle with identical certificates.
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/squid/templates/cert-manager-ca-issuer.yaml
+++ b/squid/templates/cert-manager-ca-issuer.yaml
@@ -1,0 +1,12 @@
+{{- if (index .Values "selfsigned-bundle").enabled }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ .Values.namespace.name }}-ca-issuer
+  namespace: {{ (index .Values "cert-manager").namespace }}
+  labels:
+    {{- include "squid.labels" . | nindent 4 }}
+spec:
+  ca:
+    secretName: {{ .Values.namespace.name }}-tls
+{{- end }} 

--- a/squid/templates/cert-manager-certificate.yaml
+++ b/squid/templates/cert-manager-certificate.yaml
@@ -1,0 +1,21 @@
+{{- if (index .Values "selfsigned-bundle").enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.namespace.name }}-certificate
+  namespace: {{ (index .Values "cert-manager").namespace }}
+  labels:
+    {{- include "squid.labels" . | nindent 4 }}
+spec:
+  secretName: {{ .Values.namespace.name }}-tls
+  duration: 2160h
+  renewBefore: 360h
+  commonName: {{ .Values.namespace.name }}.{{ .Values.namespace.name }}.svc
+  dnsNames:
+  - localhost
+  isCA: true
+  issuerRef:
+    name: {{ .Values.namespace.name }}-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+{{- end }} 

--- a/squid/templates/cert-manager-issuer.yaml
+++ b/squid/templates/cert-manager-issuer.yaml
@@ -1,0 +1,11 @@
+{{- if (index .Values "selfsigned-bundle").enabled }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ .Values.namespace.name }}-selfsigned-issuer
+  namespace: {{ (index .Values "cert-manager").namespace }}
+  labels:
+    {{- include "squid.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+{{- end }} 

--- a/squid/templates/cert-manager-namespace.yaml
+++ b/squid/templates/cert-manager-namespace.yaml
@@ -1,4 +1,4 @@
-{{- if (index .Values "cert-manager").enabled }}
+{{- if .Values.installCertManagerComponents }}
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/squid/templates/trust-manager-bundle.yaml
+++ b/squid/templates/trust-manager-bundle.yaml
@@ -1,0 +1,17 @@
+{{- if (index .Values "selfsigned-bundle").enabled }}
+apiVersion: trust.cert-manager.io/v1alpha1
+kind: Bundle
+metadata:
+  name: {{ .Values.namespace.name }}-ca-bundle
+  labels:
+    {{- include "squid.labels" . | nindent 4 }}
+spec:
+  sources:
+  - secret:
+      name: "{{ .Values.namespace.name }}-tls"
+      key: "ca.crt"
+  - useDefaultCAs: true
+  target:
+    configMap:
+      key: "ca-bundle.crt"
+{{- end }} 

--- a/squid/values.yaml
+++ b/squid/values.yaml
@@ -130,7 +130,11 @@ namespace:
   name: proxy
   annotations: {}
 
-# Cert-manager configuration
+# Cert-manager and Trust-manager installation control
+# Set to true to install cert-manager and trust-manager components
+installCertManagerComponents: true
+
+# Cert-manager and Trust-manager configuration
 # Based on https://cert-manager.io/docs/installation/helm/
 cert-manager:
   enabled: true  # Set to true to enable cert-manager
@@ -181,3 +185,16 @@ cert-manager:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+
+
+trust-manager:
+  crds:
+    enabled: false
+    keep: false
+  namespace: "cert-manager"
+
+
+# Issuer configuration
+# Creates a self-signed issuer and bundle in the cert-manager namespace
+selfsigned-bundle:
+  enabled: true  # Set to true to create a self-signed issuer and bundle


### PR DESCRIPTION
In order to be able to create a bundle after installation we have to first make sure the bundle CRD is ready and that the trust-manager deployment is ready.
It can be achieved by creating the resources we need as template and not as post-install hook.

- Added the trust-manager's CRDs to the crds folder
- Added an option to prevent `cert-manager` and `trust-manager` from being installed (`--set installCertManagerComponents=false`) in case we are using a cluster with both already installed.
- Added an option to prevent the resources from being created by adding `--set selfsigned-bundle.enabled=false` to the helm installation command.
- Resources were added as templates instead of a post-install hook
- The config map will be spread to all namespaces

By using the added flags we can control what will be installed:
  ```
  # Install squid + cert-manager + trust-manager + resources
  helm install squid ./squid
  ```

  ```
  # Install squid without cert-manager, without trust-manager and without creating resources
  helm install squid ./squid --set installCertManagerComponents=false --set selfsigned-bundle.enabled=false
  ```

  ```
  # Install squid + cert-manager + trust-manager without creating resources
  helm install squid ./squid --set selfsigned-bundle.enabled=false
  ```

  ```
  # Install squid without cert-manager, without trust-manager + create resources
  helm install squid ./squid --set installCertManagerComponents=false
  ```


### NOTES:
- We can control the namespaces the configmap will be shared to by adding a  `namespaceSelector` with 
` matchLabels`.
- The trust-manager's CRDs were extracted from trust-manager by using the `make` command `make generate-crds`, we should check how can we automate it

### TESTS
The tests that were running in order to check this configuration are:
1. Deploy everything (squid + cert-manager + trust-manager + resources)
     - Create a new kind cluster
     - Install the helm chart
     - Check that all the needed resources were created
     - repeat 10 times (to make sure we have no race condition that we missed)
2. Deploy only squid + resources (cert/trust-manager are already deployed on the cluster)
    - Create a new kind cluster
    - Install cert-manager and trust-manager (not from the helm chart)
    - Make sure we have a kind cluster with cert/trust-manager up and running
    - Install the helm chart with `--set installCertManagerComponents=false` to skip cert/trust-manager installation from the chart
     - Check that all the needed resources were created
     - repeat 10 times (to make sure we have no race condition that we missed)

All the tests passed