### PR TITLE
fix: update squid.conf to prevent permission errors

### DIFF
--- a/squid/squid.conf
+++ b/squid/squid.conf
@@ -92,3 +92,4 @@ coredump_dir none
 refresh_pattern ^ftp:           1440    20%     10080
 refresh_pattern -i (/cgi-bin/|\?) 0     0%      0
 refresh_pattern .               0       20%     4320 
+pid_filename none


### PR DESCRIPTION
Add `pid_filename none` to the squid.conf file to prevent this error:

```
2025/07/10 11:19:47| Processing Configuration File: /etc/squid/squid.conf (depth 0) 2025/07/10 11:19:47| FATAL: failed to open /run/squid.pid: (13) Permission denied
    exception location: File.cc(191) open
2025/07/10 11:19:47| Processing Configuration File: /etc/squid/squid.conf (depth 0) 2025/07/10 11:19:47| FATAL: failed to open /run/squid.pid: (13) Permission denied
    exception location: File.cc(191) open

```