### PR TITLE
ci(KFLUXVNGD-389): add pull-requests write permission for linter PR comments

### DIFF
--- a/.github/workflows/devcontainer-ci.yml
+++ b/.github/workflows/devcontainer-ci.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   build-devcontainer:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Add pull-requests: write permission to DevContainer CI workflow to enable automated posting of linter results as pull request comments. This minimal change allows future linting tools like reviewdog to post inline comments on code quality issues directly in pull requests.