### PR TITLE
KFLUXVNGD-388: HTTP Caching Round-Trip Test

### DIFF
--- a/squid/templates/test-pod.yaml
+++ b/squid/templates/test-pod.yaml
@@ -38,6 +38,10 @@ spec:
       value: "{{ include "squid.fullname" . }}"
     - name: SQUID_SERVICE_PORT
       value: "{{ .Values.service.port }}"
+    - name: POD_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
     resources:
       {{- toYaml .Values.test.resources | nindent 6 }}
 {{- end }} 

--- a/squid/templates/test-pod.yaml
+++ b/squid/templates/test-pod.yaml
@@ -29,7 +29,7 @@ spec:
       
       # Run the compiled test binary
       echo "Running tests..."
-      cd /tests
+      cd /app/tests
       ./e2e/e2e.test -ginkgo.v
     env:
     - name: SQUID_NAMESPACE

--- a/test.Containerfile
+++ b/test.Containerfile
@@ -26,16 +26,19 @@ ENV GOCACHE="/tmp/go-cache"
 # Install Ginkgo CLI (version-locked)
 RUN go install github.com/onsi/ginkgo/v2/ginkgo@v2.23.4
 
-# Create test directory structure
-WORKDIR /tests
+# Create working directory
+WORKDIR /app
 
-# Copy test source files and dependencies
-COPY tests/e2e/ ./e2e/
+# Copy module files first
 COPY go.mod go.sum ./
+
+# Copy test source files maintaining directory structure
+COPY tests/ ./tests/
 
 # Set up Go module and compile tests at build time
 RUN go mod download && \
     go mod tidy && \
+    cd tests && \
     ginkgo build ./e2e
 
 # Create a non-root user for running tests
@@ -43,4 +46,4 @@ RUN adduser --uid 1001 --gid 0 --shell /bin/bash --create-home testuser
 USER 1001
 
 # Default command runs the compiled test binary
-CMD ["./e2e/e2e.test", "-ginkgo.v"] 
+CMD ["./tests/e2e/e2e.test", "-ginkgo.v"] 

--- a/tests/e2e/squid_deployment_test.go
+++ b/tests/e2e/squid_deployment_test.go
@@ -1,16 +1,11 @@
 package e2e_test
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
-	"net"
 	"net/http"
-	"net/http/httptest"
-	"net/url"
-	"sync/atomic"
 	"time"
 
+	"github.com/konflux-ci/caching/tests/testhelpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -208,64 +203,22 @@ var _ = Describe("Squid Helm Chart Deployment", func() {
 
 	Describe("HTTP Caching Functionality", func() {
 		var (
-			testServer    *httptest.Server
-			testServerURL string
-			requestCount  int32
-			proxyURL      *url.URL
-			client        *http.Client
+			testServer *testhelpers.ProxyTestServer
+			client     *http.Client
 		)
 
 		BeforeEach(func() {
-			// Reset request counter
-			atomic.StoreInt32(&requestCount, 0)
-
-			// Create test HTTP server that tracks requests
-			// Use unstarted server so we can configure the listener
-			testServer = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				count := atomic.AddInt32(&requestCount, 1)
-
-				// Add cache headers to make content cacheable
-				w.Header().Set("Cache-Control", "public, max-age=300")
-				w.Header().Set("Content-Type", "application/json")
-
-				// Return JSON response with request count
-				response := map[string]interface{}{
-					"message":     "Hello from test server",
-					"request_id":  count,
-					"timestamp":   time.Now().Unix(),
-					"server_hits": count,
-				}
-
-				jsonResponse, _ := json.Marshal(response)
-				w.Write(jsonResponse)
-			}))
-
-			// Configure server to listen on all interfaces and start it
-			testServer.Listener, _ = net.Listen("tcp", "0.0.0.0:0")
-			testServer.Start()
-
-			// Get the pod's IP address to construct accessible URL
+			// Get the pod's IP address for cross-pod communication
 			podIP, err := getPodIP()
 			Expect(err).NotTo(HaveOccurred(), "Failed to get pod IP")
 
-			// Construct test server URL using pod IP instead of localhost
-			_, port, _ := net.SplitHostPort(testServer.Listener.Addr().String())
-			testServerURL = fmt.Sprintf("http://%s:%s", podIP, port)
+			// Create test server using helpers
+			testServer, err = testhelpers.NewProxyTestServer("Hello from test server", podIP)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create test server")
 
-			// Set up proxy URL to squid service
-			proxyURL, err = url.Parse(fmt.Sprintf("http://%s.%s.svc.cluster.local:3128", serviceName, namespace))
-			Expect(err).NotTo(HaveOccurred(), "Failed to parse proxy URL")
-
-			// Create HTTP client with proxy configuration
-			transport := &http.Transport{
-				Proxy: http.ProxyURL(proxyURL),
-				// Disable keep-alive to ensure fresh connections
-				DisableKeepAlives: true,
-			}
-			client = &http.Client{
-				Transport: transport,
-				Timeout:   30 * time.Second,
-			}
+			// Create HTTP client configured for Squid proxy using helpers
+			client, err = testhelpers.NewSquidProxyClient(serviceName, namespace)
+			Expect(err).NotTo(HaveOccurred(), "Failed to create proxy client")
 		})
 
 		AfterEach(func() {
@@ -276,72 +229,64 @@ var _ = Describe("Squid Helm Chart Deployment", func() {
 
 		It("should cache HTTP responses and serve subsequent requests from cache", func() {
 			By("Making the first HTTP request through Squid proxy")
-			resp1, err := client.Get(testServerURL)
+			resp1, body1, err := testhelpers.MakeProxyRequest(client, testServer.URL)
 			Expect(err).NotTo(HaveOccurred(), "First request should succeed")
 			defer resp1.Body.Close()
-
-			body1, err := io.ReadAll(resp1.Body)
-			Expect(err).NotTo(HaveOccurred(), "Should read first response body")
 
 			// Debug: print the actual response for troubleshooting
 			fmt.Printf("DEBUG: Response status: %s\n", resp1.Status)
 			fmt.Printf("DEBUG: Response body: %s\n", string(body1))
-			fmt.Printf("DEBUG: Test server URL: %s\n", testServerURL)
+			fmt.Printf("DEBUG: Test server URL: %s\n", testServer.URL)
 
-			var response1 map[string]interface{}
-			err = json.Unmarshal(body1, &response1)
+			response1, err := testhelpers.ParseTestServerResponse(body1)
 			Expect(err).NotTo(HaveOccurred(), "Should parse first response JSON")
 
-			// Verify first request reached the server
-			Expect(response1["request_id"]).To(Equal(float64(1)), "First request should hit server")
-			Expect(atomic.LoadInt32(&requestCount)).To(Equal(int32(1)), "Server should have received 1 request")
+			// Verify first request reached the server using helpers
+			testhelpers.ValidateServerHit(response1, 1, testServer)
 
 			By("Making the second HTTP request for the same URL")
 			// Wait a moment to ensure any timing-related caching issues are avoided
 			time.Sleep(100 * time.Millisecond)
 
-			resp2, err := client.Get(testServerURL)
+			resp2, body2, err := testhelpers.MakeProxyRequest(client, testServer.URL)
 			Expect(err).NotTo(HaveOccurred(), "Second request should succeed")
 			defer resp2.Body.Close()
 
-			body2, err := io.ReadAll(resp2.Body)
-			Expect(err).NotTo(HaveOccurred(), "Should read second response body")
-
-			var response2 map[string]interface{}
-			err = json.Unmarshal(body2, &response2)
+			response2, err := testhelpers.ParseTestServerResponse(body2)
 			Expect(err).NotTo(HaveOccurred(), "Should parse second response JSON")
 
 			By("Verifying the second request was served from cache")
-			// The second response should be identical to the first (from cache)
-			Expect(response2["request_id"]).To(Equal(float64(1)), "Second request should be served from cache with same request_id")
-			Expect(atomic.LoadInt32(&requestCount)).To(Equal(int32(1)), "Server should still have received only 1 request")
+			// Use helper to validate cache hit
+			testhelpers.ValidateCacheHit(response1, response2, 1)
+
+			// Server should still have received only 1 request
+			Expect(testServer.GetRequestCount()).To(Equal(int32(1)), "Server should still have received only 1 request")
 
 			// Response bodies should be identical (served from cache)
 			Expect(string(body2)).To(Equal(string(body1)), "Cached response should be identical to original")
 
 			By("Verifying cache headers are present")
-			// Check that appropriate cache-related headers are present
-			Expect(resp1.Header.Get("Cache-Control")).To(ContainSubstring("max-age=300"))
-			Expect(resp2.Header.Get("Cache-Control")).To(ContainSubstring("max-age=300"))
+			testhelpers.ValidateCacheHeaders(resp1)
+			testhelpers.ValidateCacheHeaders(resp2)
 		})
 
 		It("should handle different URLs independently", func() {
 			By("Making requests to different endpoints")
 
 			// First URL
-			resp1, err := client.Get(testServerURL + "/endpoint1")
+			resp1, _, err := testhelpers.MakeProxyRequest(client, testServer.URL+"/endpoint1")
 			Expect(err).NotTo(HaveOccurred())
 			defer resp1.Body.Close()
 
-			initialCount := atomic.LoadInt32(&requestCount)
+			initialCount := testServer.GetRequestCount()
 
 			// Second URL (different from first)
-			resp2, err := client.Get(testServerURL + "/endpoint2")
+			resp2, _, err := testhelpers.MakeProxyRequest(client, testServer.URL+"/endpoint2")
 			Expect(err).NotTo(HaveOccurred())
 			defer resp2.Body.Close()
 
 			// Both requests should hit the server (different URLs)
-			Expect(atomic.LoadInt32(&requestCount)).To(Equal(initialCount+1), "Different URLs should not be cached together")
+			Expect(testServer.GetRequestCount()).To(Equal(initialCount+1), "Different URLs should not be cached together")
 		})
 	})
 })

--- a/tests/e2e/squid_deployment_test.go
+++ b/tests/e2e/squid_deployment_test.go
@@ -1,7 +1,15 @@
 package e2e_test
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -195,6 +203,145 @@ var _ = Describe("Squid Helm Chart Deployment", func() {
 			// Basic configuration checks
 			Expect(squidConf).To(ContainSubstring("http_port 3128"))
 			Expect(squidConf).To(ContainSubstring("acl localnet src"))
+		})
+	})
+
+	Describe("HTTP Caching Functionality", func() {
+		var (
+			testServer    *httptest.Server
+			testServerURL string
+			requestCount  int32
+			proxyURL      *url.URL
+			client        *http.Client
+		)
+
+		BeforeEach(func() {
+			// Reset request counter
+			atomic.StoreInt32(&requestCount, 0)
+
+			// Create test HTTP server that tracks requests
+			// Use unstarted server so we can configure the listener
+			testServer = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				count := atomic.AddInt32(&requestCount, 1)
+
+				// Add cache headers to make content cacheable
+				w.Header().Set("Cache-Control", "public, max-age=300")
+				w.Header().Set("Content-Type", "application/json")
+
+				// Return JSON response with request count
+				response := map[string]interface{}{
+					"message":     "Hello from test server",
+					"request_id":  count,
+					"timestamp":   time.Now().Unix(),
+					"server_hits": count,
+				}
+
+				jsonResponse, _ := json.Marshal(response)
+				w.Write(jsonResponse)
+			}))
+
+			// Configure server to listen on all interfaces and start it
+			testServer.Listener, _ = net.Listen("tcp", "0.0.0.0:0")
+			testServer.Start()
+
+			// Get the pod's IP address to construct accessible URL
+			podIP, err := getPodIP()
+			Expect(err).NotTo(HaveOccurred(), "Failed to get pod IP")
+
+			// Construct test server URL using pod IP instead of localhost
+			_, port, _ := net.SplitHostPort(testServer.Listener.Addr().String())
+			testServerURL = fmt.Sprintf("http://%s:%s", podIP, port)
+
+			// Set up proxy URL to squid service
+			proxyURL, err = url.Parse(fmt.Sprintf("http://%s.%s.svc.cluster.local:3128", serviceName, namespace))
+			Expect(err).NotTo(HaveOccurred(), "Failed to parse proxy URL")
+
+			// Create HTTP client with proxy configuration
+			transport := &http.Transport{
+				Proxy: http.ProxyURL(proxyURL),
+				// Disable keep-alive to ensure fresh connections
+				DisableKeepAlives: true,
+			}
+			client = &http.Client{
+				Transport: transport,
+				Timeout:   30 * time.Second,
+			}
+		})
+
+		AfterEach(func() {
+			if testServer != nil {
+				testServer.Close()
+			}
+		})
+
+		It("should cache HTTP responses and serve subsequent requests from cache", func() {
+			By("Making the first HTTP request through Squid proxy")
+			resp1, err := client.Get(testServerURL)
+			Expect(err).NotTo(HaveOccurred(), "First request should succeed")
+			defer resp1.Body.Close()
+
+			body1, err := io.ReadAll(resp1.Body)
+			Expect(err).NotTo(HaveOccurred(), "Should read first response body")
+
+			// Debug: print the actual response for troubleshooting
+			fmt.Printf("DEBUG: Response status: %s\n", resp1.Status)
+			fmt.Printf("DEBUG: Response body: %s\n", string(body1))
+			fmt.Printf("DEBUG: Test server URL: %s\n", testServerURL)
+
+			var response1 map[string]interface{}
+			err = json.Unmarshal(body1, &response1)
+			Expect(err).NotTo(HaveOccurred(), "Should parse first response JSON")
+
+			// Verify first request reached the server
+			Expect(response1["request_id"]).To(Equal(float64(1)), "First request should hit server")
+			Expect(atomic.LoadInt32(&requestCount)).To(Equal(int32(1)), "Server should have received 1 request")
+
+			By("Making the second HTTP request for the same URL")
+			// Wait a moment to ensure any timing-related caching issues are avoided
+			time.Sleep(100 * time.Millisecond)
+
+			resp2, err := client.Get(testServerURL)
+			Expect(err).NotTo(HaveOccurred(), "Second request should succeed")
+			defer resp2.Body.Close()
+
+			body2, err := io.ReadAll(resp2.Body)
+			Expect(err).NotTo(HaveOccurred(), "Should read second response body")
+
+			var response2 map[string]interface{}
+			err = json.Unmarshal(body2, &response2)
+			Expect(err).NotTo(HaveOccurred(), "Should parse second response JSON")
+
+			By("Verifying the second request was served from cache")
+			// The second response should be identical to the first (from cache)
+			Expect(response2["request_id"]).To(Equal(float64(1)), "Second request should be served from cache with same request_id")
+			Expect(atomic.LoadInt32(&requestCount)).To(Equal(int32(1)), "Server should still have received only 1 request")
+
+			// Response bodies should be identical (served from cache)
+			Expect(string(body2)).To(Equal(string(body1)), "Cached response should be identical to original")
+
+			By("Verifying cache headers are present")
+			// Check that appropriate cache-related headers are present
+			Expect(resp1.Header.Get("Cache-Control")).To(ContainSubstring("max-age=300"))
+			Expect(resp2.Header.Get("Cache-Control")).To(ContainSubstring("max-age=300"))
+		})
+
+		It("should handle different URLs independently", func() {
+			By("Making requests to different endpoints")
+
+			// First URL
+			resp1, err := client.Get(testServerURL + "/endpoint1")
+			Expect(err).NotTo(HaveOccurred())
+			defer resp1.Body.Close()
+
+			initialCount := atomic.LoadInt32(&requestCount)
+
+			// Second URL (different from first)
+			resp2, err := client.Get(testServerURL + "/endpoint2")
+			Expect(err).NotTo(HaveOccurred())
+			defer resp2.Body.Close()
+
+			// Both requests should hit the server (different URLs)
+			Expect(atomic.LoadInt32(&requestCount)).To(Equal(initialCount+1), "Different URLs should not be cached together")
 		})
 	})
 })

--- a/tests/testhelpers/proxy_test_helpers.go
+++ b/tests/testhelpers/proxy_test_helpers.go
@@ -1,0 +1,163 @@
+package testhelpers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"time"
+
+	. "github.com/onsi/gomega"
+)
+
+// TestServerResponse represents the standard JSON response from test servers
+type TestServerResponse struct {
+	Message    string  `json:"message"`
+	RequestID  float64 `json:"request_id"`
+	Timestamp  int64   `json:"timestamp"`
+	ServerHits float64 `json:"server_hits"`
+}
+
+// ProxyTestServer wraps an HTTP test server with request counting and proxy-friendly configuration
+type ProxyTestServer struct {
+	*httptest.Server
+	RequestCount *int32
+	PodIP        string
+	URL          string
+}
+
+// NewProxyTestServer creates a new test server configured for cross-pod communication
+func NewProxyTestServer(message string, podIP string) (*ProxyTestServer, error) {
+	var requestCount int32
+
+	// Create HTTP server with request tracking
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&requestCount, 1)
+
+		// Add cache headers to make content cacheable
+		w.Header().Set("Cache-Control", "public, max-age=300")
+		w.Header().Set("Content-Type", "application/json")
+
+		// Return JSON response with request count
+		response := TestServerResponse{
+			Message:    message,
+			RequestID:  float64(count),
+			Timestamp:  time.Now().Unix(),
+			ServerHits: float64(count),
+		}
+
+		jsonResponse, _ := json.Marshal(response)
+		w.Write(jsonResponse)
+	}))
+
+	// Configure server to listen on all interfaces (required for cross-pod communication)
+	listener, err := net.Listen("tcp", "0.0.0.0:0")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create listener: %w", err)
+	}
+	server.Listener = listener
+	server.Start()
+
+	// Construct URL using pod IP instead of localhost
+	_, port, _ := net.SplitHostPort(server.Listener.Addr().String())
+	serverURL := fmt.Sprintf("http://%s:%s", podIP, port)
+
+	return &ProxyTestServer{
+		Server:       server,
+		RequestCount: &requestCount,
+		PodIP:        podIP,
+		URL:          serverURL,
+	}, nil
+}
+
+// GetRequestCount returns the current request count
+func (pts *ProxyTestServer) GetRequestCount() int32 {
+	return atomic.LoadInt32(pts.RequestCount)
+}
+
+// ResetRequestCount resets the request counter to zero
+func (pts *ProxyTestServer) ResetRequestCount() {
+	atomic.StoreInt32(pts.RequestCount, 0)
+}
+
+// NewSquidProxyClient creates an HTTP client configured to use the Squid proxy
+func NewSquidProxyClient(serviceName, namespace string) (*http.Client, error) {
+	// Set up proxy URL to squid service
+	proxyURL, err := url.Parse(fmt.Sprintf("http://%s.%s.svc.cluster.local:3128", serviceName, namespace))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse proxy URL: %w", err)
+	}
+
+	// Create HTTP client with proxy configuration
+	transport := &http.Transport{
+		Proxy: http.ProxyURL(proxyURL),
+		// Disable keep-alive to ensure fresh connections for cache testing
+		DisableKeepAlives: true,
+	}
+
+	return &http.Client{
+		Transport: transport,
+		Timeout:   30 * time.Second,
+	}, nil
+}
+
+// MakeProxyRequest makes an HTTP request through the Squid proxy and returns the response
+func MakeProxyRequest(client *http.Client, url string) (*http.Response, []byte, error) {
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, nil, fmt.Errorf("request failed: %w", err)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		resp.Body.Close()
+		return nil, nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	return resp, body, nil
+}
+
+// ParseTestServerResponse parses a JSON response from a test server
+func ParseTestServerResponse(body []byte) (*TestServerResponse, error) {
+	var response TestServerResponse
+	err := json.Unmarshal(body, &response)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse JSON response: %w", err)
+	}
+	return &response, nil
+}
+
+// ValidateCacheHit verifies that a response was served from cache
+func ValidateCacheHit(originalResponse, cachedResponse *TestServerResponse, expectedRequestID float64) {
+	// Both responses should have the same request ID (indicating cache hit)
+	Expect(cachedResponse.RequestID).To(Equal(expectedRequestID),
+		"Cached response should have same request_id as original")
+
+	// Cache should preserve the original timestamp
+	Expect(cachedResponse.Timestamp).To(Equal(originalResponse.Timestamp),
+		"Cached response should preserve original timestamp")
+
+	// Server hits should remain the same (no additional server requests)
+	Expect(cachedResponse.ServerHits).To(Equal(originalResponse.ServerHits),
+		"Cached response should show same server hit count")
+}
+
+// ValidateCacheHeaders verifies that appropriate cache headers are present
+func ValidateCacheHeaders(resp *http.Response) {
+	Expect(resp.Header.Get("Cache-Control")).To(ContainSubstring("max-age=300"),
+		"Response should have cache control headers")
+	Expect(resp.Header.Get("Content-Type")).To(Equal("application/json"),
+		"Response should have correct content type")
+}
+
+// ValidateServerHit verifies that a request actually hit the server
+func ValidateServerHit(response *TestServerResponse, expectedRequestID float64, server *ProxyTestServer) {
+	Expect(response.RequestID).To(Equal(expectedRequestID),
+		"Request should have expected request ID")
+	Expect(server.GetRequestCount()).To(Equal(int32(expectedRequestID)),
+		"Server should have received expected number of requests")
+}


### PR DESCRIPTION
### Summary 
Implements comprehensive HTTP caching validation tests for Squid proxy behavior with subsequent refactoring for improved maintainability.

### Changes
- Added HTTP caching validation tests that use an in-process HTTP server to validate Squid caching behavior
- Implemented round-trip testing with atomic request counting to ensure first request hits the server while subsequent requests are served from cache
- Refactored test components into reusable helpers package (tests/testhelpers/proxy_test_helpers.go)
- Improved code maintainability by reducing test code from 80+ lines to 40 lines per test while enhancing type safety