### PR TITLE
ci(KFLUXVNGD-415): Konflux pipeline in merge-queue

### DIFF
--- a/.tekton/squid-pull-request.yaml
+++ b/.tekton/squid-pull-request.yaml
@@ -10,12 +10,13 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" && target_branch == "main" ||
-      event == "merge_group" && target_branch == "main"
+      event == "push" && target_branch.startsWith("gh-readonly-queue/main/")
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: caching
     appstudio.openshift.io/component: squid
     pipelines.appstudio.openshift.io/type: build
+    release.appstudio.openshift.io/auto-release: "false"
   name: squid-on-pull-request
   namespace: konflux-vanguard-tenant
 spec:


### PR DESCRIPTION
Our Konflux on-pr pipeline is not triggering in GitHub merge queues
despite the configuration looking like it aught to do so.

Following the documentation in the link bellow to try to fix this:
https://konflux.pages.redhat.com/docs/users/patterns/github-merge-queues.html

Please do not add this PR to the merge queue! I will try to make the Konflux check mandatory before doing so, to make sure it works.