### PR TITLE
fix: pin Fedora to stable v42, prevent pre-release upgrades

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,11 +16,17 @@
       "automerge": true
     },
     {
-      "description": "Group container base image updates",
+      "description": "Pin Fedora to stable version 42, block pre-release versions",
+      "matchPackagePatterns": ["registry.fedoraproject.org/fedora"],
+      "allowedVersions": "/^42(\\.|$)/",
+      "automerge": false,
+      "groupName": "fedora-updates"
+    },
+    {
+      "description": "Group container base image updates (excluding Fedora)",
       "groupName": "container-images",
       "matchPackagePatterns": [
-        "registry.access.redhat.com/",
-        "registry.fedoraproject.org/"
+        "registry.access.redhat.com/"
       ],
       "matchUpdateTypes": ["patch", "digest"],
       "automerge": true


### PR DESCRIPTION
Prevents Renovate from automatically upgrading Fedora container images to pre-release versions. Should manually edit regex for future versions.