### PR TITLE
enable safe auto-merge for more renovate dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,13 +7,15 @@
       "description": "Auto-merge patch updates for Konflux components",
       "matchUpdateTypes": ["patch", "digest"],
       "matchPackagePatterns": ["^quay.io/konflux-ci/"],
-      "automerge": true
+      "automerge": true,
+      "autoApprove": true
     },
     {
       "description": "Group Tekton bundle updates together",
       "groupName": "tekton-bundles",
       "matchPackagePatterns": ["quay.io/konflux-ci/tekton-catalog/"],
-      "automerge": true
+      "automerge": true,
+      "autoApprove": true
     },
     {
       "description": "Group container base image updates",
@@ -23,7 +25,23 @@
         "registry.fedoraproject.org/"
       ],
       "matchUpdateTypes": ["patch", "digest"],
-      "automerge": true
+      "automerge": true,
+      "autoApprove": true
+    },
+    {
+      "description": "Auto-merge Go toolchain patch updates only",
+      "matchPackageNames": ["go"],
+      "matchDatasources": ["golang-version"],
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+      "autoApprove": true
+    },
+    {
+      "description": "Group Go dependencies for manual review",
+      "groupName": "go-dependencies",
+      "matchDatasources": ["go"],
+      "automerge": false,
+      "autoApprove": false
     }
   ]
 } 


### PR DESCRIPTION
added automerge for go and go-dependencies, set autoApprove to true