### PR TITLE
chore(KFLUXVNGD-402): Use our own squid-exporter image

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,10 @@ mage kind:down        # Remove cluster
 mage kind:upClean     # Force recreate cluster
 
 # Image management
-mage build:squid      # Build squid image
-mage build:loadSquid  # Load image into cluster
+mage build:squid             # Build squid image
+mage build:squidExporter     # Build squid-exporter image
+mage build:loadSquid         # Load squid image into cluster
+mage build:loadSquidExporter # Load squid-exporter image into cluster
 
 # Deployment management
 mage squidHelm:up     # Deploy/upgrade helm chart
@@ -268,7 +270,7 @@ When adding new tests:
 5. **Update VS Code config**: Add debug configurations for new test files
 ## Prometheus Monitoring
 
-This chart includes comprehensive Prometheus monitoring capabilities through the standard [squid-exporter](https://github.com/boynux/squid-exporter). The monitoring system provides detailed metrics about Squid's operational status, including:
+This chart includes comprehensive Prometheus monitoring capabilities through the [squid-exporter](https://github.com/konflux-ci/squid-exporter) (forked from the original boynux implementation). The monitoring system provides detailed metrics about Squid's operational status, including:
 
 - **Liveness**: Squid service information and connection status
 - **Bandwidth Usage**: Client HTTP and Server HTTP traffic metrics
@@ -948,8 +950,10 @@ kind delete cluster --name caching
 #### Clean Up Local Images
 
 ```bash
-# Remove the local container image
+# Remove the local container images
 podman rmi localhost/konflux-ci/squid:latest
+podman rmi localhost/konflux-ci/squid-exporter:latest
+podman rmi localhost/konflux-ci/squid-test:latest
 ```
 
 ## Chart Structure

--- a/squid-exporter/Containerfile
+++ b/squid-exporter/Containerfile
@@ -1,0 +1,42 @@
+# Build stage - Use UBI10 go-toolset with digest pin
+FROM registry.access.redhat.com/ubi10/go-toolset@sha256:228b210d2186224fbdd73de208e27e83a6f9e68ada279d6bc4dbe3d06d1cbbef AS builder
+
+# Switch to root user for package installation
+USER 0
+
+# Set working directory
+WORKDIR /workspace
+
+# Clone the konflux-ci fork of squid-exporter
+RUN git clone https://github.com/konflux-ci/squid-exporter.git .
+
+# Initialize Go module if not present and build
+RUN if [ ! -f go.mod ]; then go mod init squid-exporter; go mod tidy; fi && \
+    CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o squid-exporter .
+
+# Runtime stage - Use UBI10 with digest pin
+FROM registry.access.redhat.com/ubi10/ubi@sha256:158b70012c4898a0951abc5b4f98cefff6ec6bff3fb99957ff2f1793df7c681a
+
+# Create non-root user
+RUN useradd -r -u 1001 -g 0 squid-exporter
+
+# Copy the binary from builder stage
+COPY --from=builder /workspace/squid-exporter /usr/local/bin/squid-exporter
+
+# Set ownership and permissions
+RUN chown 1001:0 /usr/local/bin/squid-exporter && \
+    chmod +x /usr/local/bin/squid-exporter
+
+# Switch to non-root user
+USER 1001
+
+# Expose the metrics port
+EXPOSE 9301
+
+# Health check using TCP connection instead of curl
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD /bin/sh -c "exec 3<>/dev/tcp/localhost/9301 && echo -e 'GET /metrics HTTP/1.1\r\nHost: localhost\r\n\r\n' >&3 && grep -q 'HTTP/1.1 200' <&3"
+
+# Default command
+ENTRYPOINT ["/usr/local/bin/squid-exporter"]
+CMD ["-squid-hostname", "localhost", "-squid-port", "3128", "-listen", ":9301"] 

--- a/squid/values.yaml
+++ b/squid/values.yaml
@@ -63,10 +63,10 @@ service:
 squidExporter:
   # Enable or disable the squid-exporter sidecar
   enabled: true
-  # Squid exporter container image
+  # Squid exporter container image - using konflux-ci fork instead of third-party
   image:
-    repository: boynux/squid-exporter
-    tag: "v1.13.0"
+    repository: localhost/konflux-ci/squid-exporter
+    tag: "latest"
     pullPolicy: IfNotPresent
   # Port on which the exporter will serve metrics
   port: 9301


### PR DESCRIPTION
Instead of using third party image, use our own squid-exporter image.

Jira-Url: https://issues.redhat.com/browse/KFLUXVNGD-402

Assisted-by: Cursor