### PR TITLE
chore: remove snyk from pipelines and add missing labels

### DIFF
--- a/.tekton/squid-pull-request.yaml
+++ b/.tekton/squid-pull-request.yaml
@@ -364,32 +364,6 @@ spec:
         operator: in
         values:
         - "false"
-    - name: sast-snyk-check
-      params:
-      - name: image-digest
-        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: SOURCE_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-      - name: CACHI2_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-      runAfter:
-      - build-image-index
-      taskRef:
-        params:
-        - name: name
-          value: sast-snyk-check-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:fe5e5ba3a72632cd505910de2eacd62c9d11ed570c325173188f8d568ac60771
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
     - name: clamav-scan
       params:
       - name: image-digest

--- a/.tekton/squid-push.yaml
+++ b/.tekton/squid-push.yaml
@@ -358,32 +358,6 @@ spec:
         operator: in
         values:
         - "false"
-    - name: sast-snyk-check
-      params:
-      - name: image-digest
-        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: SOURCE_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-      - name: CACHI2_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-      runAfter:
-      - build-image-index
-      taskRef:
-        params:
-        - name: name
-          value: sast-snyk-check-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:fe5e5ba3a72632cd505910de2eacd62c9d11ed570c325173188f8d568ac60771
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
     - name: clamav-scan
       params:
       - name: image-digest

--- a/.tekton/squid-tester-pull-request.yaml
+++ b/.tekton/squid-tester-pull-request.yaml
@@ -366,32 +366,6 @@ spec:
         operator: in
         values:
         - "false"
-    - name: sast-snyk-check
-      params:
-      - name: image-digest
-        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: SOURCE_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-      - name: CACHI2_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-      runAfter:
-      - build-image-index
-      taskRef:
-        params:
-        - name: name
-          value: sast-snyk-check-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:fe5e5ba3a72632cd505910de2eacd62c9d11ed570c325173188f8d568ac60771
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
     - name: clamav-scan
       params:
       - name: image-digest

--- a/.tekton/squid-tester-push.yaml
+++ b/.tekton/squid-tester-push.yaml
@@ -363,32 +363,6 @@ spec:
         operator: in
         values:
         - "false"
-    - name: sast-snyk-check
-      params:
-      - name: image-digest
-        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      - name: SOURCE_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-      - name: CACHI2_ARTIFACT
-        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-      runAfter:
-      - build-image-index
-      taskRef:
-        params:
-        - name: name
-          value: sast-snyk-check-oci-ta
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:fe5e5ba3a72632cd505910de2eacd62c9d11ed570c325173188f8d568ac60771
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
     - name: clamav-scan
       params:
       - name: image-digest

--- a/test.Containerfile
+++ b/test.Containerfile
@@ -46,5 +46,15 @@ RUN go mod download && \
 RUN adduser --uid 1001 --gid 0 --shell /bin/bash --create-home testuser
 USER 1001
 
+LABEL name="Konflux CI Squid Tester"
+LABEL summary="Konflux CI Squid Tester"
+LABEL description="Konflux CI Squid Tester"
+LABEL maintainer="bkorren@redhat.com"
+LABEL com.redhat.component="konflux-ci-squid-tester"
+LABEL io.k8s.description="Konflux CI Squid Tester"
+LABEL io.k8s.display-name="konflux-ci-squid-tester"
+LABEL io.openshift.expose-services="3128:squid"
+LABEL io.openshift.tags="squid-tester"
+
 # Default command runs the compiled test binary
 CMD ["./tests/e2e/e2e.test", "-ginkgo.v"] 


### PR DESCRIPTION
The Conforma policy usually used for images is excluding snyk from the requirement not to skip checks, but the current policy we're using doesn't. It does exclude it from the required tasks, so we can remove that that task altogether for now.

Also, adding labels to the tester containerfile.