### PR TITLE
test: verify snapshot is consistent

### DIFF
--- a/.github/workflows/tekton-integration-test.yml
+++ b/.github/workflows/tekton-integration-test.yml
@@ -1,0 +1,30 @@
+name: Tekton Integration Pipeline Tests
+
+on:
+  pull_request:
+  merge_group:
+    types: [checks_requested]
+  push:
+    branches: [ main ]
+
+jobs:
+  test-tekton-pipelines:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Setup test environment
+      run: |
+        cd integration-tests
+        ./scripts/setup-test-environment.sh
+
+    - name: Run integration tests
+      run: |
+        cd integration-tests
+        ./scripts/run-tests.sh
+

--- a/integration-tests/config/kind-config.yaml
+++ b/integration-tests/config/kind-config.yaml
@@ -1,0 +1,8 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraPortMappings:
+  - containerPort: 30000
+    hostPort: 30000
+    protocol: TCP

--- a/integration-tests/scripts/run-tests.sh
+++ b/integration-tests/scripts/run-tests.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Logging functions
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INTEGRATION_TESTS_DIR="$(dirname "$SCRIPT_DIR")"
+TEST_DATA_DIR="$INTEGRATION_TESTS_DIR/test-data"
+
+# Test results tracking
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# Function to run a single test
+run_test() {
+    local test_name="$1"
+    local snapshot_file="$2"
+    local expected_result="$3"  # "success" or "failure"
+    local pipelinerun_name="test-${test_name}"
+
+    log_info "=== Running test: $test_name ==="
+
+    # Read snapshot data
+    if [ ! -f "$snapshot_file" ]; then
+        log_error "Snapshot file not found: $snapshot_file"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+
+    local snapshot_data
+    snapshot_data=$(cat "$snapshot_file")
+
+    # Create PipelineRun YAML with generateName
+    cat << EOF > "/tmp/${pipelinerun_name}.yaml"
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  generateName: ${pipelinerun_name}-
+  namespace: tekton-test
+spec:
+  pipelineRef:
+    name: verify-grouped-snapshot
+  params:
+  - name: SNAPSHOT
+    value: '${snapshot_data}'
+EOF
+
+    # Apply PipelineRun and capture the generated name
+    local actual_pipelinerun_name
+    if ! actual_pipelinerun_name=$(kubectl create -f "/tmp/${pipelinerun_name}.yaml" -n tekton-test -o jsonpath='{.metadata.name}'); then
+        log_error "Failed to create PipelineRun for test: $test_name"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+        return 1
+    fi
+
+    log_info "Created PipelineRun: $actual_pipelinerun_name"
+
+    # Wait for PipelineRun to complete
+    log_info "Waiting for PipelineRun to complete..."
+    if [ "$expected_result" = "success" ]; then
+        if kubectl wait --for=condition=Succeeded=True --timeout=300s "pipelinerun/${actual_pipelinerun_name}" -n tekton-test; then
+            log_success "Test '$test_name' passed (expected success, got success)"
+            TESTS_PASSED=$((TESTS_PASSED + 1))
+        else
+            log_error "Test '$test_name' failed (expected success, got failure)"
+            TESTS_FAILED=$((TESTS_FAILED + 1))
+        fi
+    else
+        # Expected failure - wait for failure condition or timeout
+        if kubectl wait --for=condition=Succeeded=False --timeout=300s "pipelinerun/${actual_pipelinerun_name}" -n tekton-test 2>/dev/null; then
+            log_success "Test '$test_name' passed (expected failure, got failure)"
+            TESTS_PASSED=$((TESTS_PASSED + 1))
+        else
+            # Check if it actually succeeded (which would be wrong)
+            local pr_status
+            pr_status=$(kubectl get pipelinerun "${actual_pipelinerun_name}" -n tekton-test -o jsonpath='{.status.conditions[0].status}' 2>/dev/null || echo "Unknown")
+            if [ "$pr_status" = "True" ]; then
+                log_error "Test '$test_name' failed (expected failure, got success)"
+                TESTS_FAILED=$((TESTS_FAILED + 1))
+            else
+                log_success "Test '$test_name' passed (expected failure, got failure)"
+                TESTS_PASSED=$((TESTS_PASSED + 1))
+            fi
+        fi
+    fi
+
+    # Show logs for debugging
+    log_info "Pipeline logs for test '$test_name':"
+
+    # Get the pod associated with this pipelinerun and show its logs
+    local pod_name
+    pod_name=$(kubectl get pipelinerun "${actual_pipelinerun_name}" -n tekton-test -o jsonpath='{.status.pipelineRunStatusFields.childReferences[0].name}' 2>/dev/null || echo "")
+
+    if [ -n "$pod_name" ]; then
+        log_info "Getting logs from pod: $pod_name"
+        kubectl logs "$pod_name" -n tekton-test --all-containers=true || echo "Failed to get logs from pod"
+    else
+        log_warning "No pod found for pipelinerun ${actual_pipelinerun_name}, checking taskruns..."
+        # Fallback: try to get logs from taskruns
+        local taskruns
+        taskruns=$(kubectl get taskrun -n tekton-test -l tekton.dev/pipelineRun="${actual_pipelinerun_name}" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+        if [ -n "$taskruns" ]; then
+            for tr in $taskruns; do
+                log_info "Getting logs from taskrun: $tr"
+                kubectl logs -l tekton.dev/taskRun="$tr" -n tekton-test --all-containers=true || echo "Failed to get logs from taskrun $tr"
+            done
+        else
+            log_warning "No taskruns found for pipelinerun ${actual_pipelinerun_name}"
+        fi
+    fi
+
+    # Cleanup
+    rm -f "/tmp/${pipelinerun_name}.yaml"
+
+    echo ""
+}
+
+# Main test execution
+log_info "Starting Tekton pipeline tests..."
+
+# Ensure we're in the right context
+kubectl config set-context --current --namespace=tekton-test
+
+# Test 1: Invalid snapshot (should fail)
+run_test "invalid-snapshot" "$TEST_DATA_DIR/snapshot-invalid.json" "failure"
+
+# Test 2: Valid snapshot (should pass)
+run_test "valid-snapshot" "$TEST_DATA_DIR/snapshot-valid.json" "success"
+
+# Test 3: Empty snapshot (should fail)
+run_test "empty-snapshot" "$TEST_DATA_DIR/snapshot-empty.json" "failure"
+
+# Test 4: Single component (should pass)
+run_test "single-snapshot" "$TEST_DATA_DIR/snapshot-single.json" "success"
+
+# Test summary
+echo ""
+log_info "=== Test Summary ==="
+echo "Tests passed: $TESTS_PASSED"
+echo "Tests failed: $TESTS_FAILED"
+echo "Total tests: $((TESTS_PASSED + TESTS_FAILED))"
+
+# Show all PipelineRuns
+echo ""
+log_info "All PipelineRuns in tekton-test namespace:"
+kubectl get pipelinerun -n tekton-test -o custom-columns="NAME:.metadata.name,STATUS:.status.conditions[0].status,REASON:.status.conditions[0].reason"
+
+# Exit with appropriate code
+if [ $TESTS_FAILED -eq 0 ]; then
+    log_success "All tests passed! 🎉"
+    exit 0
+else
+    log_error "Some tests failed!"
+    exit 1
+fi

--- a/integration-tests/scripts/setup-test-environment.sh
+++ b/integration-tests/scripts/setup-test-environment.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Logging functions
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INTEGRATION_TESTS_DIR="$(dirname "$SCRIPT_DIR")"
+CONFIG_DIR="$INTEGRATION_TESTS_DIR/config"
+
+log_info "Setting up Tekton test environment..."
+
+# Install required tools
+log_info "Installing required tools..."
+
+# Install kubectl
+if ! command -v kubectl &> /dev/null; then
+    log_info "Installing kubectl..."
+    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+    chmod +x kubectl
+    sudo mv kubectl /usr/local/bin/
+    log_success "kubectl installed"
+else
+    log_info "kubectl already installed"
+fi
+
+# Install kind
+if ! command -v kind &> /dev/null; then
+    log_info "Installing kind..."
+    curl -Lo ./kind "https://kind.sigs.k8s.io/dl/v0.29.0/kind-linux-amd64"
+    chmod +x ./kind
+    sudo mv ./kind /usr/local/bin/kind
+    log_success "kind installed"
+else
+    log_info "kind already installed"
+fi
+
+# Create Kind cluster
+log_info "Creating Kind cluster for Tekton testing..."
+if kind get clusters | grep -q "tekton-test"; then
+    log_warning "Kind cluster 'tekton-test' already exists, deleting it..."
+    kind delete cluster --name tekton-test
+fi
+
+kind create cluster --name tekton-test --config "$CONFIG_DIR/kind-config.yaml"
+kubectl cluster-info --context kind-tekton-test
+log_success "Kind cluster created"
+
+# Install Tekton Pipelines
+log_info "Installing Tekton Pipelines..."
+kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+
+# Wait for Tekton components to be ready
+log_info "Waiting for Tekton Pipelines to be ready..."
+kubectl wait --for=condition=Available --timeout=180s deployment/tekton-pipelines-controller -n tekton-pipelines
+kubectl wait --for=condition=Available --timeout=180s deployment/tekton-pipelines-webhook -n tekton-pipelines
+log_success "Tekton Pipelines installed and ready"
+
+# Create test namespace
+log_info "Creating test namespace..."
+kubectl create namespace tekton-test
+kubectl config set-context --current --namespace=tekton-test
+log_success "Test namespace created"
+
+# Install the pipeline under test
+log_info "Installing verify-grouped-snapshot pipeline..."
+kubectl apply -f "$INTEGRATION_TESTS_DIR/verify-grouped-snapshot.yaml" -n tekton-test
+
+# Wait for pipeline to be available
+log_info "Waiting for pipeline to be available..."
+timeout=60
+counter=0
+while ! kubectl get pipeline verify-grouped-snapshot -n tekton-test > /dev/null 2>&1; do
+    if [ $counter -ge $timeout ]; then
+        log_error "Pipeline not ready after ${timeout}s"
+        exit 1
+    fi
+    sleep 1
+    counter=$((counter + 1))
+done
+
+log_success "Pipeline installed and ready"
+log_success "Test environment setup complete!"
+
+# Show cluster status
+log_info "Cluster status:"
+kubectl get all -n tekton-test

--- a/integration-tests/test-data/snapshot-empty.json
+++ b/integration-tests/test-data/snapshot-empty.json
@@ -1,0 +1,6 @@
+{
+  "spec": {
+    "application": "test-app",
+    "components": []
+  }
+}

--- a/integration-tests/test-data/snapshot-invalid.json
+++ b/integration-tests/test-data/snapshot-invalid.json
@@ -1,0 +1,27 @@
+{
+  "spec": {
+    "application": "test-app",
+    "components": [
+      {
+        "name": "component-1",
+        "containerImage": "quay.io/test/component1@sha256:abc123",
+        "source": {
+          "git": {
+            "url": "https://github.com/example/repo",
+            "revision": "commit-sha-1"
+          }
+        }
+      },
+      {
+        "name": "component-2",
+        "containerImage": "quay.io/test/component2@sha256:def456",
+        "source": {
+          "git": {
+            "url": "https://github.com/example/repo",
+            "revision": "commit-sha-2"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/integration-tests/test-data/snapshot-single.json
+++ b/integration-tests/test-data/snapshot-single.json
@@ -1,0 +1,17 @@
+{
+  "spec": {
+    "application": "test-app",
+    "components": [
+      {
+        "name": "only-component",
+        "containerImage": "quay.io/test/component@sha256:abc123",
+        "source": {
+          "git": {
+            "url": "https://github.com/example/repo",
+            "revision": "some-commit-sha"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/integration-tests/test-data/snapshot-valid.json
+++ b/integration-tests/test-data/snapshot-valid.json
@@ -1,0 +1,37 @@
+{
+  "spec": {
+    "application": "test-app",
+    "components": [
+      {
+        "name": "component-1",
+        "containerImage": "quay.io/test/component1@sha256:abc123",
+        "source": {
+          "git": {
+            "url": "https://github.com/example/repo",
+            "revision": "commit-sha-same"
+          }
+        }
+      },
+      {
+        "name": "component-2",
+        "containerImage": "quay.io/test/component2@sha256:def456",
+        "source": {
+          "git": {
+            "url": "https://github.com/example/repo",
+            "revision": "commit-sha-same"
+          }
+        }
+      },
+      {
+        "name": "component-3",
+        "containerImage": "quay.io/test/component3@sha256:ghi789",
+        "source": {
+          "git": {
+            "url": "https://github.com/different/repo",
+            "revision": "different-commit-sha"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/integration-tests/verify-grouped-snapshot.yaml
+++ b/integration-tests/verify-grouped-snapshot.yaml
@@ -1,0 +1,162 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: verify-grouped-snapshot
+  annotations:
+    description: |
+      Verifies that snapshot components using the same Git repository URL
+      have consistent Git revisions across all components.
+spec:
+  params:
+    - name: SNAPSHOT
+      type: string
+      description: |
+        Snapshot spec containing components to validate. Expected format:
+        {
+          "spec": {
+            "components": [
+              {
+                "name": "component-name",
+                "containerImage": "quay.io/...",
+                "source": {
+                  "git": {
+                    "url": "https://github.com/...",
+                    "revision": "sha-or-tag"
+                  }
+                }
+              }
+            ]
+          }
+        }
+  tasks:
+    - name: validate-grouped-revisions
+      params:
+        - name: SNAPSHOT
+          value: "$(params.SNAPSHOT)"
+      taskSpec:
+        params:
+          - name: SNAPSHOT
+            type: string
+        steps:
+          - name: validate-revisions
+            image: quay.io/konflux-ci/appstudio-utils:latest
+            env:
+              - name: SNAPSHOT
+                value: "$(params.SNAPSHOT)"
+            script: |
+              #!/usr/bin/bash
+              set -euxo pipefail
+
+              echo "=== Snapshot Validation: Grouped Git Revision Consistency ==="
+              echo "Validating that components sharing the same Git URL have identical revisions..."
+
+              # Parse snapshot and extract component information
+              echo "Parsing snapshot components..."
+              COMPONENTS=$(echo "$SNAPSHOT" | jq -r '.spec.components[] | @base64')
+
+              if [ -z "$COMPONENTS" ]; then
+                echo "ERROR: No components found in snapshot"
+                exit 1
+              fi
+
+              # Create associative arrays to track URL->revision mappings
+              declare -A url_revisions
+              declare -A url_components
+              declare -A revision_conflicts
+
+              component_count=0
+
+              # Process each component
+              while IFS= read -r component_b64; do
+                if [ -z "$component_b64" ]; then
+                  continue
+                fi
+
+                component=$(echo "$component_b64" | base64 -d)
+                component_count=$((component_count + 1))
+
+                name=$(echo "$component" | jq -r '.name // "unknown"')
+                git_url=$(echo "$component" | jq -r '.source.git.url // empty')
+                git_revision=$(echo "$component" | jq -r '.source.git.revision // empty')
+
+                echo "Component $component_count: $name"
+                echo "  Git URL: $git_url"
+                echo "  Git Revision: $git_revision"
+
+                # Skip components without git source
+                if [ -z "$git_url" ] || [ "$git_url" = "null" ]; then
+                  echo "  → Skipping (no git source)"
+                  continue
+                fi
+
+                if [ -z "$git_revision" ] || [ "$git_revision" = "null" ]; then
+                  echo "  → ERROR: Component has git URL but no revision"
+                  exit 1
+                fi
+
+                # Check if we've seen this URL before
+                if [ -n "${url_revisions[$git_url]:-}" ]; then
+                  # URL already seen, check revision consistency
+                  existing_revision="${url_revisions[$git_url]}"
+                  existing_components="${url_components[$git_url]}"
+
+                  if [ "$git_revision" != "$existing_revision" ]; then
+                    echo "  → CONFLICT DETECTED!"
+                    echo "     Expected revision: $existing_revision (used by: $existing_components)"
+                    echo "     Found revision: $git_revision (used by: $name)"
+                    revision_conflicts[$git_url]=1
+                  else
+                    echo "  → OK: Revision matches existing components"
+                    url_components[$git_url]="${existing_components}, $name"
+                  fi
+                else
+                  # First time seeing this URL
+                  url_revisions[$git_url]="$git_revision"
+                  url_components[$git_url]="$name"
+                  echo "  → OK: First component for this repository"
+                fi
+
+              done <<< "$COMPONENTS"
+
+              echo ""
+              echo "=== Validation Summary ==="
+              echo "Total components processed: $component_count"
+              # Count unique repositories safely
+              repo_count=0
+              for url in "${!url_revisions[@]}"; do
+                repo_count=$((repo_count + 1))
+              done
+              echo "Unique repositories found: $repo_count"
+
+              # Check if we have any revision conflicts (safe for empty arrays)
+              conflict_count=0
+              for key in "${!revision_conflicts[@]}"; do
+                conflict_count=$((conflict_count + 1))
+                break  # We only need to know if there's at least one
+              done
+
+              if [ $conflict_count -eq 0 ]; then
+                echo ""
+                echo "✅ SUCCESS: All components using the same Git repository have consistent revisions"
+                echo ""
+                echo "Repository groupings:"
+                for url in "${!url_revisions[@]}"; do
+                  echo "  $url @ ${url_revisions[$url]}"
+                  echo "    Components: ${url_components[$url]}"
+                done
+                echo ""
+                echo "Snapshot validation passed! 🎉"
+              else
+                echo ""
+                echo "❌ FAILURE: Found revision conflicts in $conflict_count repositories"
+                echo ""
+                echo "Conflicting repositories:"
+                for url in "${!revision_conflicts[@]}"; do
+                  echo "  $url"
+                  echo "    Components: ${url_components[$url]}"
+                done
+                echo ""
+                echo "ERROR: Snapshot contains components from the same repository with different revisions."
+                echo "This indicates a grouping issue where components should be built from the same commit."
+                exit 1
+              fi


### PR DESCRIPTION
Add an integration test that verifies that a snapshot contains consistent references to each git repository.

I'm not sure if this repo is where we're going to ultimately store this integration test. For that reason, I did not integrate its tests into our existing workflow, but instead created a minimal workflow for testing it on its own.

I verified the new workflow is working against my fork here: https://github.com/yftacherzog/caching/pull/5