### PR TITLE
chore: multiple envs in helm values file

### DIFF
--- a/.github/workflows/devcontainer-ci.yml
+++ b/.github/workflows/devcontainer-ci.yml
@@ -13,21 +13,21 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
-      
+
     - name: Install podman
       run: |
         sudo apt-get update
         sudo apt-get install -y podman
-        
+
     - name: Start podman service
       run: |
         # Start user podman service for socket mounting
         systemctl --user start podman.socket
-        
+
     - name: Initialize devcontainer environment
       run: |
         # Set up git config for initialize.sh
@@ -35,7 +35,7 @@ jobs:
         git config --global user.email "actions@github.com"
         # Run initialize script to generate devcontainer.env
         bash .devcontainer/initialize.sh
-        
+
     - name: Build devcontainer
       run: |
         cd .devcontainer
@@ -45,7 +45,7 @@ jobs:
           --build-arg USER_UID=$USER_UID \
           --build-arg USER_GID=$USER_GID \
           -t devcontainer:latest ..
-        
+
     - name: Start devcontainer
       run: |
         podman run -d \
@@ -61,12 +61,12 @@ jobs:
           -e CONTAINER_HOST=unix:///var/run/podman.sock \
           devcontainer:latest \
           sleep infinity
-          
+
     - name: Wait for container to be ready
       run: |
         sleep 5
         podman exec devcontainer-test echo "Container is ready"
-        
+
     - name: Verify we're running as vscode user
       run: |
         # Check that we're running as vscode user by default
@@ -78,40 +78,40 @@ jobs:
         fi
         # Also verify user details
         podman exec devcontainer-test id vscode
-        
+
     - name: Verify workspace files and ownership
       run: |
         podman exec devcontainer-test ls -la /workspaces/caching
         podman exec devcontainer-test stat -c "%U %G" /workspaces/caching
-        
+
     - name: Verify workspace files are accessible
       run: |
         # Test that we can access files as the vscode user (default)
         podman exec devcontainer-test ls -la /workspaces/caching
         podman exec devcontainer-test cat /workspaces/caching/README.md | head -5
-        
+
     - name: Lint Squid Helm chart
       run: |
         # Run helm lint on the squid chart
         podman exec devcontainer-test helm lint /workspaces/caching/squid
-            
+
     - name: Lint main Containerfile
       run: |
         podman exec -w /workspaces/caching devcontainer-test hadolint Containerfile
-        
+
     - name: Lint test Containerfile
       run: |
         podman exec -w /workspaces/caching devcontainer-test hadolint test.Containerfile
-          
+
     - name: Lint devcontainer Containerfile
       run: |
         podman exec -w /workspaces/caching devcontainer-test hadolint .devcontainer/Containerfile
-                        
+
     - name: Deploy Kind environment
       run: |
         # Test that deploying our environment in Kind and our Helm chart works
         podman exec -w /workspaces/caching devcontainer-test mage squidHelm:up
-  
+
     - name: Run our test suite (via mirrord)
       run: |
         # Run the test suite via mirrord, so we can see detailed output
@@ -119,17 +119,17 @@ jobs:
 
     - name: Retest Kind environment
       run: |
-        # Test that out deployment is reentrant and that `helm test` works
+        # Test that our deployment is reentrant and that `helm test` works
         podman exec -w /workspaces/caching devcontainer-test mage all
 
     - name: Clean up Kind environment
       if: always()
-      run: |  
+      run: |
         podman exec -w /workspaces/caching devcontainer-test mage clean
         podman exec -w /workspaces/caching devcontainer-test kind delete cluster --name caching-ci
-  
+
     - name: Cleanup container
       if: always()
       run: |
         podman stop devcontainer-test || true
-        podman rm devcontainer-test || true 
+        podman rm devcontainer-test || true

--- a/.tekton/squid-helm-pull-request.yaml
+++ b/.tekton/squid-helm-pull-request.yaml
@@ -208,6 +208,9 @@ spec:
               ]
           - name: VERSION_SUFFIX
             value: "-on-pr"
+          - name: VALUES_FILES
+            value:
+              - "values.yaml"
         runAfter:
           - prefetch-dependencies
         taskRef:
@@ -215,7 +218,7 @@ spec:
             - name: name
               value: build-helm-chart-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-build-helm-chart-oci-ta:0.2@sha256:88df3d5924bf2d9fd3df30ff35bbf93c674cdf8dcafe924d2a939fb00ba8d261
+              value: quay.io/konflux-ci/tekton-catalog/task-build-helm-chart-oci-ta:0.3@sha256:20a6242fe7c624d314fd09c4b8b877df49d8e7f0725e86104bc4e375ab1784f0
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/squid-helm-push.yaml
+++ b/.tekton/squid-helm-push.yaml
@@ -199,10 +199,21 @@ spec:
                 {
                   "source": "localhost/konflux-ci/squid-test",
                   "target": "quay.io/redhat-user-workloads/konflux-vanguard-tenant/caching/squid-tester:{{revision}}"
+                },
+                {
+                  "source": "quay.io/konflux-ci/caching/squid",
+                  "target": "quay.io/konflux-ci/caching/squid:{{revision}}"
+                },
+                {
+                  "source": "quay.io/konflux-ci/caching/squid-test",
+                  "target": "quay.io/konflux-ci/caching/squid-test:{{revision}}"
                 }
               ]
           - name: VERSION_SUFFIX
             value: ""
+          - name: VALUES_FILES
+            value:
+              - "values.yaml"
         runAfter:
           - prefetch-dependencies
         taskRef:
@@ -210,7 +221,7 @@ spec:
             - name: name
               value: build-helm-chart-oci-ta
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-build-helm-chart-oci-ta:0.2@sha256:88df3d5924bf2d9fd3df30ff35bbf93c674cdf8dcafe924d2a939fb00ba8d261
+              value: quay.io/konflux-ci/tekton-catalog/task-build-helm-chart-oci-ta:0.3@sha256:20a6242fe7c624d314fd09c4b8b877df49d8e7f0725e86104bc4e375ab1784f0
             - name: kind
               value: task
           resolver: bundles

--- a/magefile.go
+++ b/magefile.go
@@ -347,14 +347,14 @@ func (SquidHelm) Up() error {
 	if exists {
 		// Upgrade existing release
 		fmt.Printf("⚓ Upgrading existing squid helm release and waiting for readiness...\n")
-		err = sh.Run("helm", "upgrade", "squid", "./squid", "--wait", "--timeout=120s")
+		err = sh.Run("helm", "upgrade", "squid", "./squid", "--set", "environment=dev", "--wait", "--timeout=120s")
 		if err != nil {
 			return fmt.Errorf("failed to upgrade helm chart: %w", err)
 		}
 	} else {
 		// Install new release
 		fmt.Printf("⚓ Installing squid helm chart and waiting for readiness...\n")
-		err = sh.Run("helm", "install", "squid", "./squid", "--wait", "--timeout=120s")
+		err = sh.Run("helm", "install", "squid", "./squid", "--set", "environment=dev", "--wait", "--timeout=120s")
 		if err != nil {
 			return fmt.Errorf("failed to install helm chart: %w", err)
 		}

--- a/squid/templates/_helpers.tpl
+++ b/squid/templates/_helpers.tpl
@@ -48,3 +48,28 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Get current environment - defaults to "release" if not set
+*/}}
+{{- define "squid.environment" -}}
+{{- .Values.environment | default "release" -}}
+{{- end }}
+
+{{/*
+Get squid image for current environment
+*/}}
+{{- define "squid.image" -}}
+{{- $env := include "squid.environment" . -}}
+{{- $envSettings := index .Values.envSettings $env -}}
+{{- printf "%s:%s" $envSettings.squid.image.repository $envSettings.squid.image.tag -}}
+{{- end }}
+
+{{/*
+Get test image for current environment
+*/}}
+{{- define "squid.test.image" -}}
+{{- $env := include "squid.environment" . -}}
+{{- $envSettings := index .Values.envSettings $env -}}
+{{- printf "%s:%s" $envSettings.test.image.repository $envSettings.test.image.tag -}}
+{{- end }}

--- a/squid/templates/deployment.yaml
+++ b/squid/templates/deployment.yaml
@@ -26,13 +26,13 @@ spec:
       serviceAccountName: {{ include "squid.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      
+
       # --- INIT CONTAINER ---
       # This container runs as root to prepare certificates, initialize the SSL DB,
       # and set the correct file permissions before the main Squid container starts.
       initContainers:
       - name: squid-init
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        image: "{{ include "squid.image" . }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
           # Must run as root to perform chown
@@ -49,19 +49,19 @@ spec:
             echo "Setting permissions on /var/spool/squid for user {{ .Values.securityContext.runAsUser }}..."
             # 2. Change ownership to the non-root user of the main container.
             chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsGroup }} /var/spool/squid
-            
+
             echo "Initialization complete."
- 
+
         volumeMounts:
         # Mount the shared volume.
         - name: squid-spool-vol
-          mountPath: /var/spool/squid    
+          mountPath: /var/spool/squid
 
       containers:
         - name: squid
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "squid.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
@@ -85,7 +85,7 @@ spec:
               readOnly: true
             # Mount the entire spool directory for the main container
             - name: squid-spool-vol
-              mountPath: /var/spool/squid              
+              mountPath: /var/spool/squid
         {{- if .Values.squidExporter.enabled }}
         - name: squid-exporter
           image: "{{ .Values.squidExporter.image.repository }}:{{ .Values.squidExporter.image.tag }}"

--- a/squid/templates/mirrord-target-pod.yaml
+++ b/squid/templates/mirrord-target-pod.yaml
@@ -18,7 +18,7 @@ spec:
   restartPolicy: Always  # Keep the target pod running for development
   containers:
     - name: testserver
-      image: "{{ .Values.mirrord.targetPod.image.repository }}:{{ .Values.mirrord.targetPod.image.tag }}"
+      image: "{{ include "squid.test.image" . }}"
       imagePullPolicy: {{ .Values.mirrord.targetPod.image.pullPolicy | default "IfNotPresent" }}
       command: ["/app/testserver"]
       ports:
@@ -55,4 +55,4 @@ spec:
         timeoutSeconds: 2
         successThreshold: 1
         failureThreshold: 3
-{{- end }} 
+{{- end }}

--- a/squid/templates/test-pod.yaml
+++ b/squid/templates/test-pod.yaml
@@ -22,7 +22,7 @@ spec:
   serviceAccountName: {{ include "squid.fullname" . }}-test
   containers:
   - name: ginkgo-test
-    image: "{{ .Values.test.image.repository }}:{{ .Values.test.image.tag }}"
+    image: "{{ include "squid.test.image" . }}"
     imagePullPolicy: {{ .Values.test.image.pullPolicy | default "IfNotPresent" }}
     command:
     - /bin/bash
@@ -32,7 +32,7 @@ spec:
       echo "=== Starting Ginkgo E2E Tests ==="
       echo "Target namespace: {{ .Values.namespace.name }}"
       echo "Squid service: {{ include "squid.fullname" . }}.{{ .Values.namespace.name }}.svc.cluster.local:{{ .Values.service.port }}"
-      
+
       # Run the compiled test binary
       echo "Running tests..."
       cd /app/tests
@@ -50,5 +50,4 @@ spec:
           fieldPath: status.podIP
     resources:
       {{- toYaml .Values.test.resources | nindent 6 }}
-{{- end }} 
- 
+{{- end }}

--- a/squid/values.schema.json
+++ b/squid/values.schema.json
@@ -4,31 +4,46 @@
   "title": "Squid Proxy Helm Chart Values Schema",
   "description": "JSON Schema for validating values.yaml in the Squid Helm chart",
   "type": "object",
+
   "properties": {
     "replicaCount": {
       "type": "integer",
       "minimum": 1,
       "description": "Number of replicas for the Squid deployment"
     },
+    "environment": {
+      "type": "string",
+      "enum": ["dev", "release"],
+      "description": "Environment selector for image repositories (should be set externally via --set)"
+    },
+    "envSettings": {
+      "type": "object",
+      "properties": {
+        "dev": {
+          "$ref": "#/$defs/environmentConfig",
+          "description": "Development environment settings"
+        },
+        "release": {
+          "$ref": "#/$defs/environmentConfig",
+          "description": "Release environment settings"
+        }
+      },
+      "required": ["dev", "release"],
+      "additionalProperties": false,
+      "description": "Environment-specific configuration for squid and test images"
+    },
     "image": {
       "type": "object",
       "properties": {
-        "repository": {
-          "type": "string",
-          "description": "Container image repository"
-        },
         "pullPolicy": {
           "type": "string",
           "enum": ["Always", "IfNotPresent", "Never"],
           "description": "Image pull policy"
-        },
-        "tag": {
-          "type": "string",
-          "description": "Image tag to use"
         }
       },
-      "required": ["repository", "pullPolicy", "tag"],
-      "additionalProperties": false
+      "required": ["pullPolicy"],
+      "additionalProperties": false,
+      "description": "Container image configuration (repository and tag are set dynamically by environment helpers)"
     },
     "imagePullSecrets": {
       "type": "array",
@@ -180,7 +195,7 @@
               "enum": ["Always", "IfNotPresent", "Never"]
             }
           },
-          "required": ["repository", "tag", "pullPolicy"],
+          "required": ["pullPolicy"],
           "additionalProperties": false
         },
         "port": {
@@ -456,19 +471,14 @@
         "image": {
           "type": "object",
           "properties": {
-            "repository": {
-              "type": "string"
-            },
-            "tag": {
-              "type": "string"
-            },
             "pullPolicy": {
               "type": "string",
               "enum": ["Always", "IfNotPresent", "Never"]
             }
           },
-          "required": ["repository", "tag", "pullPolicy"],
-          "additionalProperties": false
+          "required": ["pullPolicy"],
+          "additionalProperties": false,
+          "description": "Test image configuration (repository and tag are set dynamically by environment helpers)"
         },
         "resources": {
           "$ref": "#/$defs/resources"
@@ -494,19 +504,14 @@
             "image": {
               "type": "object",
               "properties": {
-                "repository": {
-                  "type": "string"
-                },
-                "tag": {
-                  "type": "string"
-                },
                 "pullPolicy": {
                   "type": "string",
                   "enum": ["Always", "IfNotPresent", "Never"]
                 }
               },
-              "required": ["repository", "tag", "pullPolicy"],
-              "additionalProperties": false
+              "required": ["pullPolicy"],
+              "additionalProperties": false,
+              "description": "Mirrord target pod image configuration (repository and tag are set dynamically by squid.test.image helper)"
             },
             "ports": {
               "type": "object",
@@ -600,6 +605,44 @@
   ],
   "additionalProperties": false,
   "$defs": {
+    "imageConfig": {
+      "type": "object",
+      "properties": {
+        "repository": {
+          "type": "string",
+          "description": "Container image repository"
+        },
+        "tag": {
+          "type": "string",
+          "description": "Container image tag"
+        }
+      },
+      "required": ["repository", "tag"],
+      "additionalProperties": false
+    },
+    "componentImageConfig": {
+      "type": "object",
+      "properties": {
+        "image": {
+          "$ref": "#/$defs/imageConfig"
+        }
+      },
+      "required": ["image"],
+      "additionalProperties": false
+    },
+    "environmentConfig": {
+      "type": "object",
+      "properties": {
+        "squid": {
+          "$ref": "#/$defs/componentImageConfig"
+        },
+        "test": {
+          "$ref": "#/$defs/componentImageConfig"
+        }
+      },
+      "required": ["squid", "test"],
+      "additionalProperties": false
+    },
     "resources": {
       "type": "object",
       "properties": {

--- a/squid/values.yaml
+++ b/squid/values.yaml
@@ -2,16 +2,38 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# Environment selector (default to release, override with --set environment=dev for development)
+environment: release
+
+# Environment-specific settings
+envSettings:
+  dev:
+    squid:
+      image:
+        repository: localhost/konflux-ci/squid
+        tag: "latest"
+    test:
+      image:
+        repository: localhost/konflux-ci/squid-test
+        tag: "latest"
+  release:
+    squid:
+      image:
+        repository: quay.io/konflux-ci/caching/squid
+        tag: "latest"
+    test:
+      image:
+        repository: quay.io/konflux-ci/caching/squid-test
+        tag: "latest"
+
 # This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
 replicaCount: 1
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
-  repository: localhost/konflux-ci/squid
   # This sets the pull policy for images.
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  # Note: repository and tag are set dynamically by environment helpers in _helpers.tpl
 
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
@@ -206,9 +228,8 @@ prometheus:
 test:
   enabled: true # Enable helm test functionality
   image:
-    repository: localhost/konflux-ci/squid-test # Custom test image with UBI base
-    tag: "latest"
     pullPolicy: IfNotPresent
+    # Note: repository and tag are set dynamically by environment helpers in _helpers.tpl
   resources:
     requests:
       cpu: 100m
@@ -224,9 +245,8 @@ mirrord:
   targetPod:
     name: "mirrord-test-target" # Name of the mirrord target pod
     image:
-      repository: localhost/konflux-ci/squid-test # Same image as tests
-      tag: "latest"
       pullPolicy: IfNotPresent
+      # Note: repository and tag are set dynamically by squid.test.image helper in _helpers.tpl
     ports:
       http: 8080 # Standard HTTP port
       testServer: 9090 # Test server port for connection stealing
@@ -310,4 +330,3 @@ sslDb:
   storage:
     size: 1Gi  # Size of the PVC for SSL database
     storageClass: ""  # Storage class to use (empty for default)
-


### PR DESCRIPTION
Adding a variable in the values file for setting the target env for
deployment. The task that builds the helm chart will then update
variables relevant for the deployment of the different environments,
and Helm helpers implemented as part of this change will select the
relevant values based on the deployment environment.

This will allow using a single values file for all environments,
constructing it during build time and releasing it as-is, rather than
having to modify it between build and release phases.