### PR TITLE
feat(KFLUXVNGD-360): Add RAM caching to Squid

### DIFF
--- a/squid/squid.conf
+++ b/squid/squid.conf
@@ -90,14 +90,31 @@ sslcrtd_children 8 startup=1 idle=1
 
 # --- END SSL BUMP CONFIGURATION ---
 
-# Uncomment and adjust the following to add a disk cache directory.
-# cache_dir ufs /var/spool/squid 100 16 256
+# --- CACHING CONFIGURATION ---
+# Memory cache configuration for in-pod RAM caching
+cache_mem 256 MB  # Allocate 256MB of RAM for caching
+
+# Memory cache settings
+memory_cache_mode always  # Always use memory cache when possible
+memory_cache_shared on    # Enables shared memory cache between Squid processes
+
+# Cache replacement policy
+cache_replacement_policy heap LFUDA  # Least Frequently Used with Dynamic Aging
+
+
+# Cache access control
+cache_effective_user squid
+cache_effective_group squid
+
+# Cache logging
+cache_log /dev/stderr
+
+# --- END CACHING CONFIGURATION ---
 
 # Logging configuration - separate streams by purpose
 # access_log -> STDOUT: HTTP request data (application logs)
 # cache_log -> STDERR: operational/administrative messages (startup, config, errors, debug)
 access_log stdio:/dev/stdout squid
-cache_log /dev/stderr
 
 # Disable core dumps
 coredump_dir none

--- a/tests/e2e/squid_deployment_test.go
+++ b/tests/e2e/squid_deployment_test.go
@@ -414,6 +414,26 @@ var _ = Describe("Squid Helm Chart Deployment", func() {
 		})
 	})
 
+	Describe("RAM Caching Verification", func() {
+		It("should verify cache_mem configuration is set for RAM-only caching", func() {
+			configMap, err := clientset.CoreV1().ConfigMaps(namespace).Get(ctx, "squid-config", metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred(), "Failed to get squid-config ConfigMap")
+
+			squidConf := configMap.Data["squid.conf"]
+
+			// Verify RAM caching configuration
+			Expect(squidConf).To(ContainSubstring("cache_mem"), "Should have cache_mem configured")
+			Expect(squidConf).To(ContainSubstring("memory_cache_mode always"), "Should use memory cache mode always")
+			Expect(squidConf).To(ContainSubstring("memory_cache_shared on"), "Should have shared memory cache enabled")
+
+			// Verify no disk cache directory is configured (RAM-only)
+			Expect(squidConf).NotTo(ContainSubstring("cache_dir"), "Should not have disk cache configured for RAM-only caching")
+
+			// Verify cache replacement policy
+			Expect(squidConf).To(ContainSubstring("cache_replacement_policy heap LFUDA"), "Should use LFUDA replacement policy")
+		})
+	})
+
 	Describe("Resources verification", func() {
 		It("should have the self-signed cluster issuer created", func() {
 			clusterIssuer, err := certManagerClient.CertmanagerV1().ClusterIssuers().Get(ctx, "proxy-self-signed-cluster-issuer", metav1.GetOptions{})

--- a/tests/e2e/squid_ssl_bump_functionality_test.go
+++ b/tests/e2e/squid_ssl_bump_functionality_test.go
@@ -136,8 +136,8 @@ var _ = Describe("Squid SSL-Bump Functionality", func() {
 		})
 	})
 
-	Describe("SSL-Bump HTTPS Caching", func() {
-		It("should cache HTTPS content in RAM proving SSL-Bump decryption works", func() {
+	Describe("SSL-Bump HTTPS RAM Caching", func() {
+		It("should cache HTTPS content in RAM proving SSL-Bump decryption and caching work", func() {
 			By("Getting Squid pod name")
 			pods, err := k8sClient.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{
 				LabelSelector: "app.kubernetes.io/name=squid",
@@ -197,7 +197,7 @@ var _ = Describe("Squid SSL-Bump Functionality", func() {
 			time.Sleep(1 * time.Second)
 
 			// Get logs after second request and verify TCP_MEM_HIT
-			By("Verifying second request was TCP_MEM_HIT")
+			By("Verifying second request was TCP_MEM_HIT (RAM cache hit)")
 			secondRequestLogs, err := k8sClient.CoreV1().Pods(namespace).GetLogs(squidPod.Name, &corev1.PodLogOptions{
 				Container: "squid",
 				SinceTime: &beforeSecondRequest,
@@ -210,8 +210,8 @@ var _ = Describe("Squid SSL-Bump Functionality", func() {
 			fmt.Printf("%s\n", secondLogOutput)
 			fmt.Printf("==========================================\n")
 
-			// Verify second request shows TCP_MEM_HIT
-			Expect(secondLogOutput).To(ContainSubstring("TCP_MEM_HIT"), "Second request should show TCP_MEM_HIT")
+			// should show TCP_MEM_HIT for RAM cache
+			Expect(secondLogOutput).To(ContainSubstring("TCP_MEM_HIT"), "Second request should show TCP_MEM_HIT (RAM cache hit)")
 			Expect(secondLogOutput).To(ContainSubstring("httpbin.org/cache/3600"), "Should show the specific URL in logs")
 
 			fmt.Printf("DEBUG: Final summary - Both requests successfully decrypted and cached!\n")


### PR DESCRIPTION
Add RAM caching to Squid.
Add e2e tests to verify RAM caching works.

Initial values for caching are:
- 256 MB RAM allocation
- Always use RAM cache
- Use `Least Frequently Used with Dynamic Aging` replacement policy

