### PR TITLE
fix: update proxy certificate dns names

### DIFF
--- a/squid/templates/proxy-certificate.yaml
+++ b/squid/templates/proxy-certificate.yaml
@@ -11,9 +11,10 @@ spec:
       - konflux
   dnsNames:
   - localhost
-  - {{ .Values.namespace.name }}.{{ .Values.namespace.name }}.svc
-  - {{ .Values.namespace.name }}.{{ .Values.namespace.name }}.svc.cluster.local
-  - {{ .Values.namespace.name }}.{{ .Values.namespace.name }}.svc.cluster.local
+  - {{ include "squid.fullname" . }}
+  - {{ include "squid.fullname" . }}.{{ .Values.namespace.name }}.svc
+  - {{ include "squid.fullname" . }}.{{ .Values.namespace.name }}.svc.cluster.local
+  
   issuerRef:
     kind: ClusterIssuer
     name: {{ .Values.namespace.name }}-ca-issuer

--- a/tests/e2e/squid_deployment_test.go
+++ b/tests/e2e/squid_deployment_test.go
@@ -512,7 +512,9 @@ var _ = Describe("Squid Helm Chart Deployment", func() {
 
 			// Verify DNS names
 			Expect(proxyCert.Spec.DNSNames).To(ContainElement("localhost"))
-			Expect(proxyCert.Spec.DNSNames).To(ContainElement(namespace + "." + namespace + ".svc"))
+			Expect(proxyCert.Spec.DNSNames).To(ContainElement("squid"))
+			Expect(proxyCert.Spec.DNSNames).To(ContainElement("squid." + namespace + ".svc"))
+			Expect(proxyCert.Spec.DNSNames).To(ContainElement("squid." + namespace + ".svc.cluster.local"))
 
 			// Verify the certificate status
 			Expect(proxyCert.Status.Conditions).NotTo(BeEmpty(), "Proxy certificate should have status conditions")


### PR DESCRIPTION
Update proxy certificate dns names to include the fullname of the squid deployment.