### PR TITLE
Update kind to v0.29.0 in the devcontainer

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -15,7 +15,7 @@ RUN dnf -y makecache && \
     rm -rf /var/cache /var/log/dnf* /var/log/yum.*
 
 # Install kind, mage, ginkgo CLI, and dlv debugger 
-RUN curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.23.0/kind-linux-amd64 && \
+RUN curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.29.0/kind-linux-amd64 && \
     chmod +x ./kind && \
     mv ./kind /usr/local/bin/kind && \
     GOBIN=/usr/local/bin go install github.com/magefile/mage@v1.15.0 && \


### PR DESCRIPTION
The prior version isn't able to load images into newer (v1.32.1+) kind nodes. See https://github.com/kubernetes-sigs/kind/issues/3853.

Upgrading to the latest version at the same time.