### PR TITLE
feat(KFLUXVNGD-452): Use internal server for testing

### DIFF
--- a/squid/squid.conf
+++ b/squid/squid.conf
@@ -19,6 +19,7 @@ acl localnet src fc00::/7               # RFC 4193 local private network range
 acl localnet src fe80::/10              # RFC 4291 link-local (directly plugged) machines
 
 acl SSL_ports port 443
+acl SSL_ports port 8443
 acl Safe_ports port 80          # http
 acl Safe_ports port 21          # ftp
 acl Safe_ports port 443         # https

--- a/squid/templates/deployment.yaml
+++ b/squid/templates/deployment.yaml
@@ -86,6 +86,12 @@ spec:
             # Mount the entire spool directory for the main container
             - name: squid-spool-vol
               mountPath: /var/spool/squid
+            {{- if .Values.test.enabled }}
+            # Mount the test-server's CA bundle for upstream trust
+            - name: test-server-ca-bundle-vol
+              mountPath: /etc/squid/trust/test-server
+              readOnly: true
+            {{- end }}
         {{- if .Values.squidExporter.enabled }}
         - name: squid-exporter
           image: "{{ include "squid.image" . }}"
@@ -162,7 +168,15 @@ spec:
         # Use emptyDir instead of PVC
         - name: squid-spool-vol
           emptyDir: {}
-
+        {{- if .Values.test.enabled }}
+        # This volume makes the ConfigMap created by the test-server-bundle available
+        - name: test-server-ca-bundle-vol
+          configMap:
+            name: test-server-bundle # This is the ConfigMap created by the Bundle in Step 5
+            items:
+            - key: ca.crt
+              path: ca.crt          
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/squid/templates/https-test-server-bundle.yaml
+++ b/squid/templates/https-test-server-bundle.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.test.enabled }}
+apiVersion: trust.cert-manager.io/v1alpha1
+kind: Bundle
+metadata:
+  name: test-server-bundle
+  namespace: proxy
+spec:
+  sources:
+  - secret:
+      name: "test-server-ca-secret"
+      key: "tls.crt"
+  target:
+    configMap:
+      key: "ca.crt"
+{{- end }}

--- a/squid/templates/https-test-server-selfsigned-issuer.yaml
+++ b/squid/templates/https-test-server-selfsigned-issuer.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.test.enabled }}
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: test-server-selfsigned-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: test-server-ca
+  namespace: cert-manager
+spec:
+  isCA: true
+  commonName: test-server-ca
+  secretName: test-server-ca-secret
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: test-server-selfsigned-issuer
+    kind: ClusterIssuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: test-server-ca-issuer
+spec:
+  ca:
+    secretName: test-server-ca-secret
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: test-server-cert
+  namespace: proxy
+spec:
+  secretName: test-server-tls
+  duration: 2160h # 90d
+  renewBefore: 360h # 15d
+  commonName: test-server.proxy.svc.cluster.local
+  dnsNames:
+  - test-server
+  - test-server.proxy
+  - test-server.proxy.svc
+  - test-server.proxy.svc.cluster.local
+  issuerRef:
+    name: test-server-ca-issuer
+    kind: ClusterIssuer
+{{- end }}

--- a/squid/templates/https-test-server.yaml
+++ b/squid/templates/https-test-server.yaml
@@ -1,0 +1,115 @@
+{{- if .Values.test.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-server
+  namespace: proxy
+  labels:
+    app: test-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test-server
+  template:
+    metadata:
+      labels:
+        app: test-server
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest
+        ports:
+        - containerPort: 443
+        volumeMounts:
+        - name: tls
+          mountPath: "/etc/nginx/tls"
+          readOnly: true
+        - name: nginx-conf
+          mountPath: "/etc/nginx/conf.d/default.conf"
+          subPath: "default.conf"
+          readOnly: true
+      volumes:
+      - name: tls
+        secret:
+          secretName: test-server-tls
+      - name: nginx-conf
+        configMap:
+          name: test-server-nginx-conf
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-server
+  namespace: proxy
+spec:
+  selector:
+    app: test-server
+  ports:
+    - protocol: TCP
+      port: 443
+      targetPort: 443
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-server-nginx-conf
+  namespace: proxy
+data:
+  default.conf: |
+    server {
+        listen 443 ssl;
+        server_name test-server.proxy.svc.cluster.local;
+
+        ssl_certificate /etc/nginx/tls/tls.crt;
+        ssl_certificate_key /etc/nginx/tls/tls.key;
+
+        # Handle SSL-Bump test paths
+        location ~ ^/ssl-bump-test/(\w+)$ {
+            set $test_id $1;
+            add_header Content-Type application/json;
+            add_header Cache-Control "no-cache, no-store, must-revalidate";
+            return 200 '{\
+            "message": "SSL-Bump test", \
+            "test_id": "$test_id", \
+            "timestamp": "$time_iso8601"\
+            }';
+        }
+
+        location /ssl-bump-test {
+            add_header Content-Type application/json;
+            add_header Cache-Control "no-cache, no-store, must-revalidate";
+            return 200 '{\
+            "message": "SSL-Bump test without ID", \
+            "timestamp": "$time_iso8601"\
+            }';
+        }
+
+        # Handle SSL-Bump cache test paths (cacheable content for cache testing)
+        location ~ ^/ssl-bump-cache-test/(\w+)$ {
+            set $test_id $1;
+            add_header Content-Type application/json;
+            add_header Cache-Control "public, max-age=300";
+            return 200 '{\
+            "message": "SSL-Bump cache test", \
+            "test_id": "$test_id", \
+            "timestamp": "$time_iso8601", \
+            "cacheable": true\
+            }';
+        }
+
+        # Default location - return a simple response for testing
+        location / {
+            add_header Content-Type text/html;
+            return 200 '<html>\
+            <head>\
+               <title>HTTPS Test Server</title>\
+            </head>\
+            <body>\
+               <h1>HTTPS Test Server</h1>\
+               <p>SSL-Bump functionality test server is running.</p>\
+            </body>\
+            </html>';
+        }
+    }
+{{- end }}

--- a/squid/templates/test-rbac.yaml
+++ b/squid/templates/test-rbac.yaml
@@ -30,11 +30,11 @@ metadata:
   {{- end }}
 rules:
 - apiGroups: [""]
-  resources: ["namespaces", "pods", "services", "endpoints", "secrets"]
-  verbs: ["get", "list", "watch", "create", "delete"]
+  resources: ["namespaces", "pods", "services", "endpoints", "secrets", "configmaps"]
+  verbs: ["get", "list", "watch", "create", "delete", "update"]
 - apiGroups: ["apps"]
   resources: ["deployments", "replicasets"]
-  verbs: ["get", "list", "watch"]
+  verbs: ["get", "list", "watch", "update"]
 - apiGroups: [""]
   resources: ["configmaps"]
   verbs: ["get", "list"]

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	certmanagerclient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
+	"github.com/konflux-ci/caching/tests/testhelpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,6 +23,9 @@ var (
 	clientset         *kubernetes.Clientset
 	certManagerClient *certmanagerclient.Clientset
 	ctx               context.Context
+
+	// Suite-level variables for squid configuration management
+	suiteSquidConfigMgr *testhelpers.SquidConfigManager
 )
 
 const (
@@ -79,6 +83,69 @@ var _ = BeforeSuite(func() {
 	// Verify we can connect to the cluster
 	_, err = clientset.CoreV1().Pods("proxy").List(ctx, metav1.ListOptions{Limit: 1})
 	Expect(err).NotTo(HaveOccurred(), "Failed to connect to Kubernetes cluster")
+
+	By("Setting up suite-level squid configuration")
+
+	// Create SquidConfigManager for suite-level configuration
+	suiteSquidConfigMgr = testhelpers.NewSquidConfigManager(
+		clientset, namespace, "squid-config", deploymentName)
+
+	// Ensure required TLS configuration is present
+	By("Ensuring required TLS configuration is present")
+	err = suiteSquidConfigMgr.EnsureRequiredTLSConfig(ctx)
+	Expect(err).NotTo(HaveOccurred(), "Failed to ensure required TLS config")
+
+	// Restart deployment if configuration was modified
+	if suiteSquidConfigMgr.WasConfigModified() {
+		By("Restarting squid deployment for suite-level config changes")
+		fmt.Printf("DEBUG: Configuration was modified, restarting deployment\n")
+
+		err = suiteSquidConfigMgr.RestartSquidDeployment(ctx)
+		Expect(err).NotTo(HaveOccurred(), "Failed to restart squid deployment")
+	} else {
+		By("TLS configuration already present, no restart needed")
+		fmt.Printf("DEBUG: Configuration was not modified, no restart needed\n")
+	}
+
+	// Set up cleanup using DeferCleanup
+	DeferCleanup(func() {
+		By("Cleaning up suite-level squid configuration")
+
+		if suiteSquidConfigMgr == nil {
+			fmt.Printf("DEBUG: No configuration manager found, skipping cleanup\n")
+			return
+		}
+
+		wasModified := suiteSquidConfigMgr.WasConfigModified()
+		fmt.Printf("DEBUG: Configuration modified: %t\n", wasModified)
+
+		if !wasModified {
+			fmt.Printf("DEBUG: No configuration changes to restore\n")
+			return
+		}
+
+		// Restore the original configuration
+		By("Restoring original squid configuration")
+		wasRestored, err := suiteSquidConfigMgr.RestoreOriginalConfig(ctx)
+		Expect(err).NotTo(HaveOccurred(), "Failed to restore original squid config")
+
+		if !wasRestored {
+			fmt.Printf("DEBUG: Configuration restoration was not needed\n")
+			return
+		}
+
+		// Restart deployment to apply restored configuration
+		By("Restarting squid deployment to apply restored configuration")
+		fmt.Printf("DEBUG: Configuration restored, restarting deployment\n")
+
+		err = suiteSquidConfigMgr.RestartSquidDeployment(ctx)
+		Expect(err).NotTo(HaveOccurred(), "Failed to restart squid deployment after restore")
+
+		fmt.Printf("DEBUG: Suite cleanup completed successfully\n")
+	})
+
+	By("Suite setup complete - Configuration is ready")
+	fmt.Printf("DEBUG: Suite-level configuration setup complete\n")
 })
 
 func TestE2e(t *testing.T) {


### PR DESCRIPTION
Add internal https server for testing.

The resources are defined in the templates folder and will deployed only if `test` is enabled.

**Workflow:**
When `test` is enabled: 

* The resources needed for the https-test-server will be deployed 
* a new volume and volumeMount with the test-server bundle configmap will be added to squid's deployment (squid needs to trust the test-server)
* In order for squid to trust the https-test-server's selfsigned ca we need to add an entry to the squid.conf file and restart squid.
* The `BeforeSuite` section of the tests is responsible for it:
    * We get the configmap from squid's deployment
    * Check if we have the correct entry `tls_outgoing_options 
    cafile=/etc/squid/trust/test-server/ca.crt`
    * If it does not exist we will add it to the correct place in the file
       * Restart squid's deployment for the change to take effect 
       * Wait for it to start
       * Continue with the tests.
    * If it exists - Continue with the tests
    
* The `AfterSuite` section is responsible for the restoration of the deployment:
   * If the configmap was updated, restore the original configmap
      * Restart squid's deployment for the change to take effect 
      * Wait for it to start
   * If it was not updated no need to revert and restart

* The beforeEach section in `squid_ssl_bump_functionality_test.go` is responsible to create a trusted client by adding it the needed bundles (test-server, squid)
