### PR TITLE
chore: remove renovate extends configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,4 @@
 {
-  "extends": ["github>konflux-ci/mintmaker//config/renovate/renovate.json"],
   "automergeStrategy": "merge-commit",
   "platformAutomerge": true,
   "packageRules": [


### PR DESCRIPTION
removing extends line as mintmaker team advised to avoid unexpected issues