### PR TITLE
fix: update helm lock file on updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -52,7 +52,17 @@
       "matchDatasources": ["go"],
       "automerge": false,
       "autoApprove": false
+    },
+    {
+      "description": "Auto-update Helm Chart.lock files when dependencies change",
+      "matchManagers": ["helmv3"],
+      "postUpgradeTasks": {
+        "commands": [
+          "cd {{{packageFileDir}}} && helm dependency update"
+        ],
+        "executionMode": "update"
+      }
     }
   ]
-} 
+}
 


### PR DESCRIPTION
Let renovate update the helm lock file upon updates to the chart file. This should update the lock file when the subcharts are updated by renovate.