### PR TITLE
Add support for a caching allow list using URL regex patterns

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -23,7 +23,7 @@ RUN curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.29.0/kind-linux-amd64 && \
     GOBIN=/usr/local/bin go install github.com/go-delve/delve/cmd/dlv@latest
 
 # Install mirrord binary securely from GitHub releases (specific version)
-ARG MIRRORD_VERSION=3.150.0
+ARG MIRRORD_VERSION=3.157.2
 RUN curl -fsSL "https://github.com/metalbear-co/mirrord/releases/download/${MIRRORD_VERSION}/mirrord_linux_x86_64" -o /usr/local/bin/mirrord && \
     chmod +x /usr/local/bin/mirrord
 

--- a/.github/workflows/devcontainer-ci.yml
+++ b/.github/workflows/devcontainer-ci.yml
@@ -15,6 +15,13 @@ jobs:
       pull-requests: write
 
     steps:
+    - name: Free disk space
+      uses: jlumbroso/free-disk-space@v1.3.1
+      with:
+        android: false
+        dotnet: false
+        haskell: false
+
     - name: Checkout repository
       uses: actions/checkout@v4
 

--- a/.mirrord/mirrord.json
+++ b/.mirrord/mirrord.json
@@ -20,5 +20,8 @@
                 "GOCACHE"
             ]
         }
+    },
+    "experimental": {
+        "vfork_emulation": true
     }
 }

--- a/squid/squid.conf
+++ b/squid/squid.conf
@@ -102,7 +102,6 @@ memory_cache_shared on    # Enables shared memory cache between Squid processes
 # Cache replacement policy
 cache_replacement_policy heap LFUDA  # Least Frequently Used with Dynamic Aging
 
-
 # Cache access control
 cache_effective_user squid
 cache_effective_group squid
@@ -123,7 +122,5 @@ coredump_dir none
 #
 # Add any of your own refresh_pattern entries above these.
 #
-refresh_pattern ^ftp:           1440    20%     10080
-refresh_pattern -i (/cgi-bin/|\?) 0     0%      0
-refresh_pattern .               0       20%     4320
+refresh_pattern . 0 20% 4320
 pid_filename none

--- a/squid/templates/configmap.yaml
+++ b/squid/templates/configmap.yaml
@@ -7,4 +7,19 @@ metadata:
     {{- include "squid.labels" . | nindent 4 }}
 data:
   squid.conf: |-
-    {{- .Files.Get "squid.conf" | nindent 4 }} 
+    {{- .Files.Get "squid.conf" | nindent 4 }}
+
+    {{- if .Values.tlsOutgoingOptions.caFile }}
+    tls_outgoing_options cafile={{ .Values.tlsOutgoingOptions.caFile }}
+    {{- end }}
+
+    {{- if .Values.cache.allowList }}
+    {{- range .Values.cache.allowList }}
+    acl cached_urls url_regex {{ . }}
+    {{- end }}
+
+    cache allow cached_urls
+    cache deny all
+    {{- else }}
+    cache allow all
+    {{- end }}

--- a/squid/templates/deployment.yaml
+++ b/squid/templates/deployment.yaml
@@ -12,10 +12,12 @@ spec:
       {{- include "squid.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        # Trigger a redeployment when the configmap changes
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "squid.selectorLabels" . | nindent 8 }}
     spec:

--- a/squid/templates/test-pod.yaml
+++ b/squid/templates/test-pod.yaml
@@ -24,6 +24,7 @@ spec:
   - name: ginkgo-test
     image: "{{ include "squid.test.image" . }}"
     imagePullPolicy: {{ .Values.test.image.pullPolicy | default "IfNotPresent" }}
+    workingDir: /app
     command:
     - /bin/bash
     - -c
@@ -35,8 +36,7 @@ spec:
 
       # Run the compiled test binary
       echo "Running tests..."
-      cd /app/tests
-      ./e2e/e2e.test -ginkgo.v
+      ./tests/e2e/e2e.test -ginkgo.v
     env:
     - name: SQUID_NAMESPACE
       value: "{{ .Values.namespace.name }}"

--- a/squid/templates/test-rbac.yaml
+++ b/squid/templates/test-rbac.yaml
@@ -29,21 +29,31 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   {{- end }}
 rules:
+# Expansive permissions are required to run `helm upgrade` from inside the test pod.
 - apiGroups: [""]
-  resources: ["namespaces", "pods", "services", "endpoints", "secrets", "configmaps"]
-  verbs: ["get", "list", "watch", "create", "delete", "update"]
+  resources: ["namespaces", "pods", "services", "endpoints", "secrets", "configmaps", "serviceaccounts"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterroles", "clusterrolebindings", "roles", "rolebindings"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
 - apiGroups: ["apps"]
-  resources: ["deployments", "replicasets"]
-  verbs: ["get", "list", "watch", "update"]
-- apiGroups: [""]
-  resources: ["configmaps"]
-  verbs: ["get", "list"]
+  resources: ["deployments", "replicasets", "daemonsets"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+- apiGroups: ["monitoring.coreos.com"]
+  resources: ["servicemonitors"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+- apiGroups: ["cert-manager.io"]
+  resources: ["certificates", "clusterissuers", "issuers"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
+- apiGroups: ["trust.cert-manager.io"]
+  resources: ["bundles"]
+  verbs: ["get", "list", "watch", "create", "delete", "update", "patch"]
 - apiGroups: [""]
   resources: ["pods/log"]
   verbs: ["get"]
-- apiGroups: ["cert-manager.io"]
-  resources: ["certificates", "clusterissuers"]
-  verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/squid/values.schema.json
+++ b/squid/values.schema.json
@@ -594,6 +594,29 @@
       "required": ["storage"],
       "additionalProperties": false,
       "description": "SSL Database configuration for persistent storage of SSL certificates"
+    },
+    "cache": {
+      "type": "object",
+      "properties": {
+        "allowList": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of URL regex patterns to cache"
+        }
+      },
+      "additionalProperties": false
+    },
+    "tlsOutgoingOptions": {
+      "type": "object",
+      "properties": {
+        "caFile": {
+          "type": "string",
+          "description": "CA file for outgoing TLS connections"
+        }
+      },
+      "additionalProperties": false
     }
   },
   "required": [

--- a/squid/values.yaml
+++ b/squid/values.yaml
@@ -324,3 +324,14 @@ sslDb:
   storage:
     size: 1Gi  # Size of the PVC for SSL database
     storageClass: ""  # Storage class to use (empty for default)
+
+# Cache configuration
+cache:
+  # Defines a list of URL patterns to cache. All other URLs are not cached.
+  # An empty list disables this feature, meaning all URL patterns are cached.
+  allowList: []
+
+# TLS outgoing options
+tlsOutgoingOptions:
+  # CA file for outgoing TLS connections
+  caFile: ""

--- a/test.Containerfile
+++ b/test.Containerfile
@@ -10,14 +10,25 @@ RUN microdnf install -y \
     gcc-14.2.1-7.el10 && \
     microdnf clean all
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Install Go (version-locked)
 ARG GO_VERSION=1.24.4
 ARG GO_SHA256=77e5da33bb72aeaef1ba4418b6fe511bc4d041873cbf82e5aa6318740df98717
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o go.tar.gz && \
     echo "${GO_SHA256}  go.tar.gz" | sha256sum -c - && \
     tar -C /usr/local -xzf go.tar.gz && \
     rm go.tar.gz
+
+# Install Helm (version-locked)
+ARG HELM_VERSION=v3.18.6
+ARG HELM_SHA256=3f43c0aa57243852dd542493a0f54f1396c0bc8ec7296bbb2c01e802010819ce
+RUN curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" -o helm.tar.gz && \
+    echo "${HELM_SHA256}  helm.tar.gz" | sha256sum -c - && \
+    mkdir -p /tmp/helm && \
+    tar -C /tmp/helm -xzf helm.tar.gz && \
+    mv /tmp/helm/linux-amd64/helm /usr/local/bin/helm && \
+    rm -rf /tmp/helm helm.tar.gz
 
 # Set Go environment
 ENV PATH="/usr/local/go/bin:/root/go/bin:$PATH"
@@ -35,6 +46,9 @@ COPY go.mod go.sum ./
 
 # Copy test source files maintaining directory structure
 COPY tests/ ./tests/
+
+# Copy squid chart
+COPY squid/ ./squid/
 
 # Set up Go module and compile tests and testserver at build time
 RUN go mod download && \

--- a/tests/e2e/squid_cache_allow_list_test.go
+++ b/tests/e2e/squid_cache_allow_list_test.go
@@ -1,0 +1,138 @@
+package e2e_test
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/konflux-ci/caching/tests/testhelpers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cache allow list tests", Ordered, func() {
+	var (
+		testServer *testhelpers.ProxyTestServer
+		client     *http.Client
+	)
+
+	BeforeEach(func() {
+		testServer = setupHTTPTestServer("Cache allow list test server")
+		client = setupHTTPTestClient()
+	})
+
+	Context("When cache.allowList is empty (default behavior)", func() {
+		It("should cache all requests by default", func() {
+			testURL := testServer.URL + "?" + generateCacheBuster("disabled-allow-list")
+
+			By("Making the first request")
+			resp1, body1, err := testhelpers.MakeProxyRequest(client, testURL)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp1.Body.Close()
+
+			response1, err := testhelpers.ParseTestServerResponse(body1)
+			Expect(err).NotTo(HaveOccurred())
+			testhelpers.ValidateServerHit(response1, 1, testServer)
+
+			By("Making the second request for the same URL")
+			time.Sleep(100 * time.Millisecond)
+			resp2, body2, err := testhelpers.MakeProxyRequest(client, testURL)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp2.Body.Close()
+
+			response2, err := testhelpers.ParseTestServerResponse(body2)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the second request was served from cache")
+			testhelpers.ValidateCacheHit(response1, response2, 1)
+			Expect(testServer.GetRequestCount()).To(Equal(int32(1)),
+				"Server should have received only 1 request (second served from cache)")
+		})
+	})
+
+	Context("When cache.allowList contains specific patterns", func() {
+		allowedPatterns := []string{
+			"^http://.*/do-cache.*",
+		}
+
+		BeforeAll(func() {
+			err := testhelpers.ConfigureSquidWithHelm(ctx, clientset, testhelpers.SquidHelmValues{
+				CacheAllowList: allowedPatterns,
+			})
+			Expect(err).NotTo(HaveOccurred(), "Failed to configure squid with cache allow list")
+
+			DeferCleanup(func() {
+				err := testhelpers.ConfigureSquidWithHelm(ctx, clientset, testhelpers.SquidHelmValues{})
+				Expect(err).NotTo(HaveOccurred(), "Failed to restore squid cache defaults")
+			})
+		})
+
+		It("should cache HTTP requests that match allowList patterns", func() {
+			// Test URL that matches the first pattern
+			matchingURL := testServer.URL + "/do-cache?" + generateCacheBuster("http-included-in-allow-list")
+
+			By("Testing URL that matches allowList pattern")
+			By(fmt.Sprintf("Testing URL: %s", matchingURL))
+
+			resp1, body1, err := testhelpers.MakeProxyRequest(client, matchingURL)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp1.Body.Close()
+
+			response1, err := testhelpers.ParseTestServerResponse(body1)
+			Expect(err).NotTo(HaveOccurred())
+			testhelpers.ValidateServerHit(response1, 1, testServer)
+
+			By("Making second request to same URL")
+			time.Sleep(100 * time.Millisecond)
+			resp2, body2, err := testhelpers.MakeProxyRequest(client, matchingURL)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp2.Body.Close()
+
+			response2, err := testhelpers.ParseTestServerResponse(body2)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the second request was served from cache")
+			testhelpers.ValidateCacheHit(response1, response2, 1)
+			Expect(testServer.GetRequestCount()).To(Equal(int32(1)),
+				"Matching URL should be cached")
+		})
+
+		It("should NOT cache requests that don't match allowList patterns", func() {
+			// Reset test server counter
+			testServer.ResetRequestCount()
+
+			// Test URL that doesn't match any pattern
+			nonMatchingURL := testServer.URL + "/dont-cache?" + generateCacheBuster("absent-from-allow-list")
+
+			By("Testing URL that doesn't match allowList patterns")
+			By(fmt.Sprintf("Testing URL: %s", nonMatchingURL))
+
+			resp1, body1, err := testhelpers.MakeProxyRequest(client, nonMatchingURL)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp1.Body.Close()
+
+			response1, err := testhelpers.ParseTestServerResponse(body1)
+			Expect(err).NotTo(HaveOccurred())
+			testhelpers.ValidateServerHit(response1, 1, testServer)
+
+			By("Making second request to same URL")
+			time.Sleep(100 * time.Millisecond)
+			resp2, body2, err := testhelpers.MakeProxyRequest(client, nonMatchingURL)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp2.Body.Close()
+
+			response2, err := testhelpers.ParseTestServerResponse(body2)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the second request was NOT served from cache")
+			// Both requests should have hit the server (no caching)
+			testhelpers.ValidateServerHit(response2, 2, testServer)
+			Expect(testServer.GetRequestCount()).To(Equal(int32(2)),
+				"Non-matching URL should not be cached, both requests should hit server")
+
+			// Request IDs should be different (not served from cache)
+			Expect(response1.RequestID).NotTo(Equal(response2.RequestID),
+				"Request IDs should be different (not cached)")
+		})
+	})
+})

--- a/tests/e2e/squid_deployment_test.go
+++ b/tests/e2e/squid_deployment_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strconv"
 	"time"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -295,31 +294,8 @@ var _ = Describe("Squid Helm Chart Deployment", func() {
 		)
 
 		BeforeEach(func() {
-			// Get the pod's IP address for cross-pod communication
-			podIP, err := getPodIP()
-			Expect(err).NotTo(HaveOccurred(), "Failed to get pod IP")
-
-			// Get test server port from environment, fallback to 0 (random port)
-			testPort := 0
-			if testPortStr := os.Getenv("TEST_SERVER_PORT"); testPortStr != "" {
-				if port, parseErr := strconv.Atoi(testPortStr); parseErr == nil {
-					testPort = port
-				}
-			}
-
-			// Create test server using helpers
-			testServer, err = testhelpers.NewProxyTestServer("Hello from test server", podIP, testPort)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create test server")
-
-			// Create HTTP client configured for Squid proxy using helpers
-			client, err = testhelpers.NewSquidProxyClient(serviceName, namespace)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create proxy client")
-		})
-
-		AfterEach(func() {
-			if testServer != nil {
-				testServer.Close()
-			}
+			testServer = setupHTTPTestServer("HTTP caching test server")
+			client = setupHTTPTestClient()
 		})
 
 		It("should cache HTTP responses and serve subsequent requests from cache", func() {

--- a/tests/e2e/squid_metrics_test.go
+++ b/tests/e2e/squid_metrics_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -158,21 +157,8 @@ var _ = Describe("Squid Proxy Metrics Integration", func() {
 
 		BeforeEach(func() {
 			By("Setting up test infrastructure")
-
-			// Get pod IP for test server
-			podIP := os.Getenv("POD_IP")
-			if podIP == "" {
-				Fail("POD_IP environment variable not set (requires downward API)")
-			}
-
-			// Create test server for generating traffic
-			var err error
-			testServer, err = testhelpers.NewProxyTestServer("Metrics Test", podIP, 0)
-			Expect(err).NotTo(HaveOccurred(), "Should create test server")
-
-			// Create proxy client
-			client, err = testhelpers.NewSquidProxyClient(serviceName, namespace)
-			Expect(err).NotTo(HaveOccurred(), "Should create proxy client")
+			testServer = setupHTTPTestServer("Metrics Test")
+			client = setupHTTPTestClient()
 
 			// Create client for metrics endpoint
 			metricsClient = &http.Client{

--- a/tests/e2e/squid_ssl_bump_functionality_test.go
+++ b/tests/e2e/squid_ssl_bump_functionality_test.go
@@ -29,6 +29,18 @@ var _ = Describe("Squid SSL-Bump Functionality", Ordered, func() {
 
 	const testServerURL = "https://test-server.proxy.svc.cluster.local:443"
 
+	BeforeAll(func() {
+		err := testhelpers.ConfigureSquidWithHelm(ctx, clientset, testhelpers.SquidHelmValues{
+			OutgoingTLSCAFile: "/etc/squid/trust/test-server/ca.crt",
+		})
+		Expect(err).NotTo(HaveOccurred(), "Failed to configure squid for SSL bump tests")
+
+		DeferCleanup(func() {
+			err := testhelpers.ConfigureSquidWithHelm(ctx, clientset, testhelpers.SquidHelmValues{})
+			Expect(err).NotTo(HaveOccurred(), "Failed to restore squid cache defaults")
+		})
+	})
+
 	BeforeEach(func() {
 		var err error
 


### PR DESCRIPTION
The allow list is disabled by default, meaning all requests are cached.

Testing this feature required a number of changes to the test code/infra:

1. The squid config manager in the e2e tests is replaced with calls to helm upgrade and templating of the configmap. The squid proxy will redeploy automatically when the content of the configmap changes.

2. Disabled keep-alives in the HTTP test server to fix an issue with reuse of port 9090 between rapid tests.

3. Upgraded mirrord to 3.157.2 to fix https://github.com/metalbear-co/mirrord/issues/2653 This required setting experimental vfork_emulration=true. Encountered https://github.com/metalbear-co/mirrord/issues/3534 when trying to use 3.158+.

4. The helm binary and the squid chart needed to be added to the test container to ensure
`helm test squid` will continue to work.

Assisted-by: cursor (claude-4-sonnet)