### PR TITLE
chore: add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+### Author's Checklist
+- [ ] I understand the problem that the PR is trying to address.
+- [ ] I understand the solution and its role and impact within the wider system.
+- [ ] I opted for automation and automated tests over documenting multiple steps.
+
+### Reviewer's Guide
+- [ ] What is the PR trying to solve?
+- [ ] Does the solution make sense?
+- [ ] How does this affect the wider system?
+- [ ] Is it being tested properly?
+- [ ] Does it keep documentation concise and maintainable?


### PR DESCRIPTION
The underlying assumption is that much of the PRs that we submit is generated by AI, but we need to somehow verify that changes make sense.

The idea is to foster a culture in which we only merge PRs for which we understand what they do and how they do it, and that they only contain the things that they need to contain, rather than everything that AI chose to generate.

Keeping the checklist as short as possible is essential for people to actually try and follow it rather than to ignore or to manipulate it.