### PR TITLE
Silently ignore non-cacheable HTTP methods in per-site exporter

### DIFF
--- a/cmd/squid-per-site-exporter/main.go
+++ b/cmd/squid-per-site-exporter/main.go
@@ -148,6 +148,14 @@ func (e *Exporter) parseLogLine(line string) {
 		return
 	}
 
+	// Silently skip uncacheable methods to avoid filling the logs with unnecessary noise.
+	// GET and HEAD requests are cacheable.
+	// POST and PATCH are conditionally cacheable if the necessary response headers are set.
+	// See: https://wiki.squid-cache.org/SquidFaq/SquidLogs#request-methods
+	if method != "GET" && method != "HEAD" && method != "POST" && method != "PATCH" {
+		return
+	}
+
 	// Parse URL to extract hostname
 	parsedURL, err := url.Parse(urlStr)
 	if err != nil {


### PR DESCRIPTION
This prevents the logs from being filled with parsing errors for CONNECT requests and ignores methods which are uncacheable according to squid.

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [x] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
