### PR TITLE
chore: remove grouping of go packages in renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -34,25 +34,6 @@
       "matchUpdateTypes": ["patch"],
       "automerge": true,
       "autoApprove": true
-    },
-    {
-      "description": "Group Kubernetes ecosystem dependencies to prevent version conflicts",
-      "groupName": "kubernetes-ecosystem",
-      "matchPackagePatterns": [
-        "^k8s.io/",
-        "^sigs.k8s.io/"
-      ],
-      "matchDatasources": ["go"],
-      "automerge": false,
-      "autoApprove": false
-    },
-    {
-      "description": "Group Go dependencies for manual review",
-      "groupName": "go-dependencies",
-      "matchDatasources": ["go"],
-      "automerge": false,
-      "autoApprove": false
     }
   ]
-} 
-
+}


### PR DESCRIPTION
As failures are quite common for renovate PRs for go updates, having upgrades grouped makes it harder to get those PRs merged.

Ungrouping should allow us to merge the ones that don't cause trouble and to more easily troubleshoot the ones that do.

### Author's Checklist
- [ ] I understand the problem that the PR is trying to address.
- [ ] I understand the solution and its role and impact within the wider system.
- [ ] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
