### PR TITLE
feat: Add tlsConfig to servicemonitor to scrape by DNS

### DIFF
--- a/squid/templates/servicemonitor.yaml
+++ b/squid/templates/servicemonitor.yaml
@@ -37,5 +37,19 @@ spec:
       interval: {{ .Values.prometheus.serviceMonitor.interval }}
       scrapeTimeout: {{ .Values.prometheus.serviceMonitor.scrapeTimeout }}
       honorLabels: true
+      {{- if .Values.prometheus.serviceMonitor.perSiteTLS.enabled }}
+      tlsConfig:
+        {{- $clusterDomain := (default "cluster.local" .Values.clusterDomain) }}
+        {{- $svcFQDN := printf "%s.%s.svc.%s" (include "squid.fullname" .) .Values.namespace.name $clusterDomain }}
+        serverName: {{ .Values.prometheus.serviceMonitor.perSiteTLS.serverName | default $svcFQDN }}
+        insecureSkipVerify: {{ .Values.prometheus.serviceMonitor.perSiteTLS.insecureSkipVerify | default false }}
+        {{- with .Values.prometheus.serviceMonitor.perSiteTLS.ca }}
+        ca:
+          secret:
+            name: {{ .secretName }}
+            key: {{ .key | default "ca.crt" }}
+        {{- end }}
+        caFile: {{ .Values.prometheus.serviceMonitor.perSiteTLS.caFile }}
+      {{- end }}
     {{- end }}
 {{- end }} 

--- a/squid/values.schema.json
+++ b/squid/values.schema.json
@@ -6,6 +6,10 @@
   "type": "object",
 
   "properties": {
+    "clusterDomain": {
+      "type": "string",
+      "description": "Kubernetes cluster DNS suffix (e.g., cluster.local). Leave empty to use default."
+    },
     "replicaCount": {
       "type": "integer",
       "minimum": 1,
@@ -442,6 +446,30 @@
                 "type": "string"
               },
               "description": "ServiceMonitor annotations"
+            },
+            "perSiteTLS": {
+              "type": "object",
+              "properties": {
+                "enabled": { "type": "boolean" },
+                "serverName": { "type": "string" },
+                "insecureSkipVerify": { "type": "boolean" },
+                "ca": {
+                  "type": "object",
+                  "properties": {
+                    "secretName": { "type": "string" },
+                    "key": { "type": "string" }
+                  },
+                  "required": ["secretName"],
+                  "additionalProperties": false
+                },
+                "caFile": { "type": "string" }
+              },
+              "required": ["enabled"],
+              "anyOf": [
+                { "required": ["ca"] },
+                { "required": ["caFile"] }
+              ],
+              "additionalProperties": false
             }
           },
           "required": ["enabled"],

--- a/squid/values.yaml
+++ b/squid/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# Cluster DNS domain. If empty, templates assume "cluster.local".
+clusterDomain: ""
+
 # Environment selector (default to release, override with --set environment=dev for development)
 environment: release
 
@@ -302,6 +305,20 @@ prometheus:
     path: "/metrics"
     # Additional annotations for the ServiceMonitor
     annotations: {}
+    # TLS options for per-site exporter scrape (9302). If enabled, Prometheus will
+    # validate the HTTPS endpoint using the provided serverName and CA.
+    perSiteTLS:
+      enabled: true
+      # Leave empty to auto-derive: <service>.<namespace>.svc.<cluster-domain>
+      serverName: ""
+      # If you don't have a CA handy, you can point to a Secret with ca.crt
+      ca:
+        secretName: "proxy-tls"
+        # key: "ca.crt" # optional, defaults to ca.crt
+      # Alternatively, reference a mounted CA file path inside Prometheus
+      # caFile: "/etc/prometheus/configmaps/proxy-ca/ca.crt"
+      # As a last resort only (not recommended), you can skip verification
+      insecureSkipVerify: false
 
 test:
   enabled: true # Enable helm test functionality


### PR DESCRIPTION
Per-site-exporter is down due to certificate issue since it doesn't contain any IP SANs so adding tlsConfig in servicemonitor to scrape by DNS

Jira-Url: https://issues.redhat.com/browse/KFLUXVNGD-476

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [x] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
