### PR TITLE
Switch to disk-based cache using a memory-backed tmpfs volume

### DIFF
--- a/container-entrypoint.sh
+++ b/container-entrypoint.sh
@@ -11,7 +11,7 @@ if [ "${1:-squid}" = "icap-server" ]; then
 fi
 
 SPOOL_DIR="/var/spool/squid"
-SSL_DB_DIR="${SPOOL_DIR}/ssl_db"
+SSL_DB_DIR="${SPOOL_DIR}/ssl/db"
 
 # Check if the ssl_db directory exists and has been initialized.
 # We check for the 'index.txt' file which is created by the certgen tool.

--- a/squid/squid.conf
+++ b/squid/squid.conf
@@ -86,7 +86,7 @@ ssl_bump bump all
 
 # Path to the helper program that generates certificates.
 # For RHEL/UBI based systems, the path is typically in /usr/lib64/squid/
-sslcrtd_program /usr/lib64/squid/security_file_certgen -s /var/spool/squid/ssl_db -M 16MB
+sslcrtd_program /usr/lib64/squid/security_file_certgen -s /var/spool/squid/ssl/db -M 16MB
 sslcrtd_children 8 startup=1 idle=1
 
 # --- END SSL BUMP CONFIGURATION ---
@@ -117,13 +117,12 @@ adaptation_access icap_server deny all
 # --- END ICAP CONFIGURATION ---
 
 # --- CACHING CONFIGURATION ---
-# Memory cache settings
-# Always use memory cache when possible
-memory_cache_mode always
-# Enable shared memory cache between Squid processes
-memory_cache_shared on
-# Purge policy when free memory is low: Least Frequently Used with Data Aging algorithm
-memory_replacement_policy heap LFUDA
+# Disable memory cache for "hot objects" and "negative-cached objects"
+# Disk cache is used instead (although backed by a tmpfs memory volume)
+cache_mem 0
+
+# Purge policy when available cache size is low: Least Frequently Used with Data Aging algorithm
+cache_replacement_policy heap LFUDA
 
 # Cache access control
 # Align with the Pod's securityContext (runAsUser: 1001, runAsGroup: 0)

--- a/squid/templates/configmap.yaml
+++ b/squid/templates/configmap.yaml
@@ -24,6 +24,10 @@ data:
     cache allow all
     {{- end }}
 
-    # --- MEMORY CACHE CONFIGURATION ---
-    cache_mem {{ .Values.cache.memory.size }}
-    maximum_object_size_in_memory {{ .Values.cache.memory.maxObjectSize }}
+    # Use an asynchronous(aufs) disk cache (backed by a tmpfs memory volume)
+    # Set storage limit at 80% of the total volume's size (per cache_dir docs)
+    # Structure: 16 first-level directories, 256 second-level subdirectories
+    cache_dir aufs /var/spool/squid/cache {{ mulf .Values.cache.memory.size 0.8 | int }} 16 256
+
+    # Maximum object size to cache
+    maximum_object_size {{ .Values.cache.memory.maxObjectSize }} MB

--- a/squid/templates/deployment.yaml
+++ b/squid/templates/deployment.yaml
@@ -73,9 +73,12 @@ spec:
             - name: squid-certs-secret
               mountPath: /etc/squid/certs
               readOnly: true
-            # Mount the entire spool directory for cache and SSL database
-            - name: squid-spool-vol
-              mountPath: /var/spool/squid
+            # Mount the cache volume
+            - name: squid-spool-cache
+              mountPath: /var/spool/squid/cache
+            # Mount the SSL database volume
+            - name: squid-spool-ssl
+              mountPath: /var/spool/squid/ssl
             {{- if .Values.test.enabled }}
             # Mount the test-server's CA bundle for upstream trust
             - name: test-server-ca-bundle-vol
@@ -185,9 +188,13 @@ spec:
         - name: squid-certs-secret
           secret:
             secretName: {{ .Values.namespace.name }}-tls
-        # Volume for Squid's entire spool directory (cache and SSL database)
-        # Use emptyDir with fsGroup for proper permissions
-        - name: squid-spool-vol
+        # Volume for Squid's cache
+        - name: squid-spool-cache
+          emptyDir:
+            medium: Memory
+            sizeLimit: {{ .Values.cache.memory.size }}Mi
+        # Volume for Squid's SSL database
+        - name: squid-spool-ssl
           emptyDir: {}
         {{- if .Values.test.enabled }}
         # This volume makes the ConfigMap created by the test-server-bundle available

--- a/squid/values.schema.json
+++ b/squid/values.schema.json
@@ -607,31 +607,6 @@
       },
       "additionalProperties": false
     },
-    "sslDb": {
-      "type": "object",
-      "properties": {
-        "storage": {
-          "type": "object",
-          "properties": {
-            "size": {
-              "type": "string",
-              "pattern": "^[0-9]+(Ei|Pi|Ti|Gi|Mi|Ki|E|P|T|G|M|K)?$",
-              "description": "Size of the PVC for SSL database storage"
-            },
-            "storageClass": {
-              "type": "string",
-              "description": "Storage class to use for the PVC (empty for default)"
-            }
-          },
-          "required": ["size", "storageClass"],
-          "additionalProperties": false,
-          "description": "Persistent storage configuration for SSL certificates"
-        }
-      },
-      "required": ["storage"],
-      "additionalProperties": false,
-      "description": "SSL Database configuration for persistent storage of SSL certificates"
-    },
     "cache": {
       "type": "object",
       "properties": {
@@ -646,14 +621,14 @@
           "type": "object",
           "properties": {
             "size": {
-              "type": "string",
-              "pattern": "^[0-9]+(\\s+(MB|GB|TB|KB|B))?$",
-              "description": "RAM allocated for caching (cache_mem)"
+              "type": "integer",
+              "minimum": 1,
+              "description": "RAM allocated for caching in MiB"
             },
             "maxObjectSize": {
-              "type": "string",
-              "pattern": "^[0-9]+(\\s+(MB|GB|TB|KB|B))?$",
-              "description": "Maximum size of objects cached in memory (maximum_object_size_in_memory)"
+              "type": "integer",
+              "minimum": 1,
+              "description": "Maximum object size to cache in MiB"
             }
           },
           "additionalProperties": false,

--- a/squid/values.yaml
+++ b/squid/values.yaml
@@ -372,13 +372,6 @@ mirrord:
   # When mirrord.enabled=true, test RBAC becomes persistent (no helm hooks)
   # When mirrord.enabled=false, test RBAC uses hooks for cleanup
 
-# SSL Database configuration
-# Persistent storage for SSL certificates
-sslDb:
-  storage:
-    size: 1Gi  # Size of the PVC for SSL database
-    storageClass: ""  # Storage class to use (empty for default)
-
 # Cache configuration
 cache:
   # Defines a list of URL patterns to cache. All other URLs are not cached.
@@ -386,10 +379,13 @@ cache:
   allowList: []
   # Memory cache configuration
   memory:
-    # RAM allocated for caching (cache_mem)
-    size: 256 MB
-    # Maximum size of objects cached in memory (maximum_object_size_in_memory)
-    maxObjectSize: 256 MB
+    # RAM allocated for caching in MiB
+    # This counts towards the pod's memory limit. It should be less than the pod's memory limit
+    # and account for the rest of the pod's memory usage.
+    size: 256
+    # Maximum object size to cache in MiB
+    # Should not exceed 80% of `size`
+    maxObjectSize: 192
 
 # TLS outgoing options
 tlsOutgoingOptions:

--- a/tests/e2e/squid_deployment_test.go
+++ b/tests/e2e/squid_deployment_test.go
@@ -434,23 +434,21 @@ var _ = Describe("Squid Helm Chart Deployment", func() {
 		})
 	})
 
-	Describe("RAM Caching Verification", func() {
-		It("should verify cache_mem configuration is set for RAM-only caching", func() {
+	Describe("Caching Verification", func() {
+		It("should verify configuration is set for disk caching", func() {
 			configMap, err := clientset.CoreV1().ConfigMaps(namespace).Get(ctx, "squid-config", metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred(), "Failed to get squid-config ConfigMap")
 
 			squidConf := configMap.Data["squid.conf"]
 
 			// Verify RAM caching configuration
-			Expect(squidConf).To(ContainSubstring("cache_mem"), "Should have cache_mem configured")
-			Expect(squidConf).To(ContainSubstring("memory_cache_mode always"), "Should use memory cache mode always")
-			Expect(squidConf).To(ContainSubstring("memory_cache_shared on"), "Should have shared memory cache enabled")
-
-			// Verify no disk cache directory is configured (RAM-only)
-			Expect(squidConf).NotTo(ContainSubstring("cache_dir"), "Should not have disk cache configured for RAM-only caching")
-
+			Expect(squidConf).To(ContainSubstring("cache_mem 0"), "Should set cache_mem to 0")
+			// Verify disk cache directory is configured
+			Expect(squidConf).To(ContainSubstring("cache_dir aufs /var/spool/squid/cache 204 16 256"), "Should have disk cache configured")
+			// Verify maximum object size is configured
+			Expect(squidConf).To(ContainSubstring("maximum_object_size 192 MB"), "Should have maximum object size configured")
 			// Verify cache replacement policy
-			Expect(squidConf).To(ContainSubstring("memory_replacement_policy heap LFUDA"), "Should use LFUDA replacement policy")
+			Expect(squidConf).To(ContainSubstring("cache_replacement_policy heap LFUDA"), "Should use LFUDA replacement policy")
 		})
 	})
 

--- a/tests/e2e/squid_ssl_bump_functionality_test.go
+++ b/tests/e2e/squid_ssl_bump_functionality_test.go
@@ -229,7 +229,7 @@ var _ = Describe("Squid SSL-Bump Functionality", Ordered, func() {
 				return nil
 			}, timeout, interval).Should(Succeed(), "First HTTPS request should eventually succeed")
 
-			By("Making second HTTPS request until successful (should be TCP_MEM_HIT)")
+			By("Making second HTTPS request until successful (should be TCP_HIT)")
 			Eventually(func() error {
 				resp2, err := trustedClient.Get(testURL)
 				if err != nil {
@@ -252,7 +252,7 @@ var _ = Describe("Squid SSL-Bump Functionality", Ordered, func() {
 			allLogs, err := testhelpers.GetPodLogsSince(ctx, clientset, namespace, squidPod.Name, "squid", &beforeSequence)
 			Expect(err).NotTo(HaveOccurred(), "Failed to get logs")
 
-			By("Verifying caching behavior: at least one TCP_MISS and at least one TCP_MEM_HIT (RAM cache hit)")
+			By("Verifying caching behavior: at least one TCP_MISS and at least one TCP_HIT (RAM cache hit)")
 			logOutput := string(allLogs)
 			fmt.Printf("DEBUG: Complete caching sequence logs:\n")
 			fmt.Printf("==========================================\n")
@@ -262,9 +262,9 @@ var _ = Describe("Squid SSL-Bump Functionality", Ordered, func() {
 			Expect(logOutput).To(ContainSubstring("TCP_MISS"), "Should show at least one TCP_MISS for the test URL")
 			Expect(logOutput).To(ContainSubstring("test-server.proxy.svc.cluster.local"), "Should show the test server URL in logs")
 			Expect(logOutput).To(ContainSubstring("ssl-bump-cache-test"), "Should show the SSL-Bump cache test endpoint in logs")
-			Expect(logOutput).To(ContainSubstring("TCP_MEM_HIT"), "Should show at least one TCP_MEM_HIT (RAM cache hit) for the test URL")
+			Expect(logOutput).To(ContainSubstring("TCP_HIT"), "Should show at least one TCP_HIT for the test URL")
 
-			fmt.Printf("DEBUG: Caching verification successful - found both TCP_MISS and TCP_MEM_HIT!\n")
+			fmt.Printf("DEBUG: Caching verification successful - found both TCP_MISS and TCP_HIT!\n")
 		})
 	})
 })


### PR DESCRIPTION
The max locked memory limit (ulimit -l) cannot be modified from a kubernetes pod. Squid can't lock more than ~8MB (at least, on a kind cluster) of storage in memory. To get around this, we can use disk based caching from squid's point of view but provide a tmpfs memory-backed volume for the storage.

Other included changes:
- The squid SSL DB and cache are now in separate volumes so they can be scaled independently.
- Removed unused sslDb persistent volume configuration that was never implemented.

Assisted-by: cursor(claude-4.5-sonnet)

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [x] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
