### PR TITLE
Remove the cache.memory value

### DIFF
--- a/squid/templates/configmap.yaml
+++ b/squid/templates/configmap.yaml
@@ -27,7 +27,7 @@ data:
     # Use an asynchronous(aufs) disk cache (backed by a tmpfs memory volume)
     # Set storage limit at 80% of the total volume's size (per cache_dir docs)
     # Structure: 16 first-level directories, 256 second-level subdirectories
-    cache_dir aufs /var/spool/squid/cache {{ mulf .Values.cache.memory.size 0.8 | int }} 16 256
+    cache_dir aufs /var/spool/squid/cache {{ mulf .Values.cache.size 0.8 | int }} 16 256
 
     # Maximum object size to cache
-    maximum_object_size {{ .Values.cache.memory.maxObjectSize }} MB
+    maximum_object_size {{ .Values.cache.maxObjectSize }} MB

--- a/squid/templates/deployment.yaml
+++ b/squid/templates/deployment.yaml
@@ -192,7 +192,7 @@ spec:
         - name: squid-spool-cache
           emptyDir:
             medium: Memory
-            sizeLimit: {{ .Values.cache.memory.size }}Mi
+            sizeLimit: {{ .Values.cache.size }}Mi
         # Volume for Squid's SSL database
         - name: squid-spool-ssl
           emptyDir: {}

--- a/squid/values.schema.json
+++ b/squid/values.schema.json
@@ -617,22 +617,15 @@
           },
           "description": "List of URL regex patterns to cache"
         },
-        "memory": {
-          "type": "object",
-          "properties": {
-            "size": {
-              "type": "integer",
-              "minimum": 1,
-              "description": "RAM allocated for caching in MiB"
-            },
-            "maxObjectSize": {
-              "type": "integer",
-              "minimum": 1,
-              "description": "Maximum object size to cache in MiB"
-            }
-          },
-          "additionalProperties": false,
-          "description": "Memory cache configuration options"
+        "size": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Size of the cache in MiB"
+        },
+        "maxObjectSize": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Maximum object size to cache in MiB"
         }
       },
       "additionalProperties": false

--- a/squid/values.yaml
+++ b/squid/values.yaml
@@ -377,15 +377,13 @@ cache:
   # Defines a list of URL patterns to cache. All other URLs are not cached.
   # An empty list disables this feature, meaning all URL patterns are cached.
   allowList: []
-  # Memory cache configuration
-  memory:
-    # RAM allocated for caching in MiB
-    # This counts towards the pod's memory limit. It should be less than the pod's memory limit
-    # and account for the rest of the pod's memory usage.
-    size: 256
-    # Maximum object size to cache in MiB
-    # Should not exceed 80% of `size`
-    maxObjectSize: 192
+  # Size of the cache in MiB
+  # This counts towards the pod's memory limit. It should be less than the pod's memory limit
+  # and account for the rest of the pod's memory usage.
+  size: 256
+  # Maximum object size to cache in MiB
+  # Should not exceed 80% of `size`
+  maxObjectSize: 192
 
 # TLS outgoing options
 tlsOutgoingOptions:


### PR DESCRIPTION
The recent change to use disk caching with a memory-backed tmpfs volume makes the `memory` key unclear. Removing it since we only have a single cache medium.

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [x] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
