### PR TITLE
Revert "chore(deps): update quay.io/jetstack/cert-manager-cainjector docker tag to v1.19.0"

### DIFF
--- a/squid/values.yaml
+++ b/squid/values.yaml
@@ -269,7 +269,7 @@ cert-manager:
     replicaCount: 1
     image:
       repository: quay.io/jetstack/cert-manager-cainjector
-      tag: v1.19.0
+      tag: v1.18.2
       pullPolicy: IfNotPresent
   resources:
     requests:


### PR DESCRIPTION
Reverts konflux-ci/caching#197.

This only partially updated cert-manager. See these other related PRs:

- https://github.com/konflux-ci/caching/pull/206
- https://github.com/konflux-ci/caching/pull/204
- https://github.com/konflux-ci/caching/pull/202
- https://github.com/konflux-ci/caching/pull/198

Since we have a go dependency on cert-manager, upgrading it also requires us to upgrade go to v1.25 (see PR #206). This is currently blocked because our Fedora dev container only supports up to v1.24.