### PR TITLE
Enable periodic DNS re-resolution for nginx upstream

### DIFF
--- a/squid/templates/nginx-configmap.yaml
+++ b/squid/templates/nginx-configmap.yaml
@@ -57,6 +57,13 @@ data:
                          inactive=7d
                          use_temp_path=off;
 
+        # Re-resolve DNS on the specified interval rather than only at startup.
+        # Nginx has no built-in default resolver for runtime DNS resolution, so
+        # one must be explicitly configured. The init container populates this
+        # from /etc/resolv.conf to ensure portability across clusters.
+        resolver __RESOLVER__ valid=60s;
+        resolver_timeout 5s;
+
         server {
             {{- if .Values.nginx.tls.enabled }}
             # HTTPS server on port 8443
@@ -81,6 +88,12 @@ data:
             listen 8080;
             {{- end }}
 
+            # Store the upstream URL in a variable so nginx periodically re-resolves
+            # DNS via the resolver directive. A static proxy_pass URL is only
+            # resolved once at config load; using a variable enables re-resolution
+            # based on the resolver's valid interval.
+            set $upstream_url "{{ .Values.nginx.upstream.url }}";
+
             # Health check endpoint for Kubernetes liveness/readiness probes.
             # Returns 200 OK without proxying the request or logging.
             location = /health {
@@ -93,7 +106,7 @@ data:
             # Cached location matching pattern: {{ . }}
             location ~ {{ . }} {
                 # Forward requests to the upstream server
-                proxy_pass {{ $.Values.nginx.upstream.url }};
+                proxy_pass $upstream_url;
 
                 # Send the upstream hostname so the backend receives the correct Host header
                 proxy_set_header Host {{ (urlParse $.Values.nginx.upstream.url).host }};
@@ -128,7 +141,7 @@ data:
             # Default location: proxy to the upstream server without caching.
             # Handles paths not matching any allowList patterns.
             location / {
-                proxy_pass {{ .Values.nginx.upstream.url }};
+                proxy_pass $upstream_url;
                 proxy_set_header Host {{ (urlParse .Values.nginx.upstream.url).host }};
                 proxy_set_header X-Real-IP $remote_addr;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/squid/templates/nginx-statefulset.yaml
+++ b/squid/templates/nginx-statefulset.yaml
@@ -32,7 +32,6 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.nginx.auth.enabled }}
       initContainers:
         - name: init-config
           image: {{ .Values.nginx.image }}
@@ -40,8 +39,12 @@ spec:
           args:
             - |
               set -e
-              AUTH_VALUE=$(cat /secrets/authorization)
-              sed "s|__AUTH_HEADER__|${AUTH_VALUE}|g" /config-template/nginx.conf > /config/nginx.conf
+              RESOLVER=$(awk '/^nameserver/{print $2; exit}' /etc/resolv.conf)
+              sed -e "s|__RESOLVER__|${RESOLVER}|g" \
+              {{- if .Values.nginx.auth.enabled }}
+                  -e "s|__AUTH_HEADER__|$(cat /secrets/authorization)|g" \
+              {{- end }}
+                  /config-template/nginx.conf > /config/nginx.conf
           resources:
             requests:
               cpu: 10m
@@ -57,10 +60,11 @@ spec:
               readOnly: true
             - name: config
               mountPath: /config
+            {{- if .Values.nginx.auth.enabled }}
             - name: auth-secret
               mountPath: /secrets
               readOnly: true
-      {{- end }}
+            {{- end }}
       containers:
         - name: nginx
           image: {{ .Values.nginx.image }}
@@ -113,17 +117,10 @@ spec:
               mountPath: /etc/nginx/tls
               readOnly: true
             {{- end }}
-            {{- if .Values.nginx.auth.enabled }}
             - name: config
               mountPath: /etc/nginx/nginx.conf
               subPath: nginx.conf
               readOnly: true
-            {{- else }}
-            - name: config-template
-              mountPath: /etc/nginx/nginx.conf
-              subPath: nginx.conf
-              readOnly: true
-            {{- end }}
       volumes:
         - name: config-template
           configMap:
@@ -133,9 +130,9 @@ spec:
           secret:
             secretName: {{ .Values.nginx.tls.secretName }}
         {{- end }}
-        {{- if .Values.nginx.auth.enabled }}
         - name: config
           emptyDir: {}
+        {{- if .Values.nginx.auth.enabled }}
         - name: auth-secret
           secret:
             secretName: {{ .Values.nginx.auth.secretName }}

--- a/tests/helm/nginx_template_test.go
+++ b/tests/helm/nginx_template_test.go
@@ -127,7 +127,7 @@ var _ = Describe("Helm Template Nginx Configuration", func() {
 	})
 
 	Describe("Nginx Auth Configuration", func() {
-		It("should not include init container when auth is disabled", func() {
+		It("should not include auth secret in init container when auth is disabled", func() {
 			output, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{
 				Nginx: &testhelpers.NginxValues{
 					Enabled: true,
@@ -142,11 +142,12 @@ var _ = Describe("Helm Template Nginx Configuration", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			statefulSet := extractNginxStatefulSetSection(output)
-			Expect(statefulSet).NotTo(ContainSubstring("initContainers"), "Should not have init containers when auth disabled")
+			Expect(statefulSet).To(ContainSubstring("initContainers"), "Should have init container for resolver substitution")
 			Expect(statefulSet).NotTo(ContainSubstring("auth-secret"), "Should not mount auth secret when auth disabled")
+			Expect(statefulSet).NotTo(ContainSubstring("__AUTH_HEADER__"), "Should not substitute auth header when auth disabled")
 		})
 
-		It("should include init container and auth volumes when auth is enabled", func() {
+		It("should substitute auth header and mount auth secret when auth is enabled", func() {
 			output, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{
 				Nginx: &testhelpers.NginxValues{
 					Enabled: true,
@@ -166,7 +167,7 @@ var _ = Describe("Helm Template Nginx Configuration", func() {
 			// Verify init container
 			Expect(statefulSet).To(ContainSubstring("initContainers"), "Should have init containers when auth enabled")
 			Expect(statefulSet).To(ContainSubstring("name: init-config"), "Should have init-config container")
-			Expect(statefulSet).To(ContainSubstring("sed \"s|__AUTH_HEADER__|${AUTH_VALUE}|g\""), "Should replace auth header placeholder")
+			Expect(statefulSet).To(ContainSubstring(`s|__AUTH_HEADER__|$(cat /secrets/authorization)|g`), "Should replace auth header placeholder")
 
 			// Verify auth secret volume
 			Expect(statefulSet).To(ContainSubstring("auth-secret"), "Should have auth-secret volume")
@@ -177,9 +178,8 @@ var _ = Describe("Helm Template Nginx Configuration", func() {
 			Expect(statefulSet).To(ContainSubstring("emptyDir: {}"), "Config volume should be emptyDir")
 		})
 
-		It("should mount config differently based on auth setting", func() {
-			// Without auth - mount config-template directly
-			outputNoAuth, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{
+		It("should always mount processed config from init container", func() {
+			output, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{
 				Nginx: &testhelpers.NginxValues{
 					Enabled: true,
 					Upstream: &testhelpers.NginxUpstreamValues{
@@ -189,27 +189,9 @@ var _ = Describe("Helm Template Nginx Configuration", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			statefulSet := extractNginxStatefulSetSection(outputNoAuth)
-			Expect(statefulSet).To(ContainSubstring("name: config-template"), "Should mount config-template when auth disabled")
-
-			// With auth - mount processed config
-			outputWithAuth, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{
-				Nginx: &testhelpers.NginxValues{
-					Enabled: true,
-					Upstream: &testhelpers.NginxUpstreamValues{
-						URL: "http://backend:8080",
-					},
-					Auth: &testhelpers.NginxAuthValues{
-						Enabled:    true,
-						SecretName: "my-secret",
-					},
-				},
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			statefulSet = extractNginxStatefulSetSection(outputWithAuth)
-			// Should mount the processed config from emptyDir, not config-template
-			Expect(statefulSet).To(MatchRegexp(`-\s+name: config\s+mountPath: /etc/nginx/nginx.conf`), "Should mount processed config when auth enabled")
+			statefulSet := extractNginxStatefulSetSection(output)
+			// Should always mount the processed config from emptyDir
+			Expect(statefulSet).To(MatchRegexp(`-\s+name: config\s+mountPath: /etc/nginx/nginx.conf`), "Should mount processed config")
 		})
 	})
 
@@ -384,7 +366,7 @@ var _ = Describe("Helm Template Nginx Configuration", func() {
 	})
 
 	Describe("Nginx ConfigMap Upstream Configuration", func() {
-		It("should configure upstream URL in all proxy_pass directives", func() {
+		It("should configure upstream URL in all locations via variable for DNS re-resolution", func() {
 			output, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{
 				Nginx: &testhelpers.NginxValues{
 					Enabled: true,
@@ -400,8 +382,9 @@ var _ = Describe("Helm Template Nginx Configuration", func() {
 
 			configMap := extractNginxConfigMapSection(output)
 
-			// Upstream URL should appear in both cached location and default location
-			Expect(strings.Count(configMap, "proxy_pass http://nexus.example.com:8081")).To(Equal(2), "Should have upstream URL in both locations")
+			// Upstream URL should be set via variable once at server level
+			Expect(strings.Count(configMap, `set $upstream_url "http://nexus.example.com:8081"`)).To(Equal(1), "Should set upstream_url variable once at server level")
+			Expect(strings.Count(configMap, "proxy_pass $upstream_url")).To(Equal(2), "Should use upstream_url variable in proxy_pass in both locations")
 
 			// Host header should be derived from the upstream URL
 			Expect(strings.Count(configMap, "proxy_set_header Host nexus.example.com:8081")).To(Equal(2), "Should derive Host header from upstream URL in both locations")


### PR DESCRIPTION
Nginx resolves DNS for static proxy_pass URLs once at config load and never re-resolves. When the upstream rotates IPs (e.g., AWS load balancers), nginx keeps connecting to stale IPs causing request timeouts.

Fix by using a variable for proxy_pass, which makes nginx re-resolve DNS via an explicit resolver directive. The resolver IP is auto-detected from /etc/resolv.conf by the init container, ensuring portability across OpenShift and Kubernetes (kind) clusters.

The init container now always runs to substitute the __RESOLVER__ placeholder, with optional __AUTH_HEADER__ substitution when auth is enabled.

Assisted-by: Claude Opus 4.6

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [x] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
