### PR TITLE
fix(KFLUXVNGD-886): add nginx DNS names to proxy certificate

### DIFF
--- a/squid/templates/proxy-certificate.yaml
+++ b/squid/templates/proxy-certificate.yaml
@@ -14,6 +14,11 @@ spec:
   - {{ .Values.squid.name }}
   - {{ .Values.squid.name }}.{{ .Values.namespace.name }}.svc
   - {{ .Values.squid.name }}.{{ .Values.namespace.name }}.svc.cluster.local
+  {{- if .Values.nginx.enabled }}
+  - {{ .Values.nginx.name }}
+  - {{ .Values.nginx.name }}.{{ .Values.namespace.name }}.svc
+  - {{ .Values.nginx.name }}.{{ .Values.namespace.name }}.svc.cluster.local
+  {{- end }}
   
   issuerRef:
     kind: ClusterIssuer


### PR DESCRIPTION
Adds nginx service DNS names to the shared proxy certificate to fix Prometheus ServiceMonitor TLS verification failures when scraping the nginx access-log-exporter metrics endpoint.

The certificate now includes SANs for both squid and nginx services, allowing Prometheus to successfully verify the TLS connection to nginx.caching.svc.cluster.local:9113.

Jira-Url: https://redhat.atlassian.net/browse/KFLUXVNGD-886


Assisted-by: Claude Sonnet 4.5 (via Claude Code)

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [x] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
