### PR TITLE
fix(KFLUXVNGD-891): decouple nginx access-log-exporter TLS from squid certificate chain

### DIFF
--- a/squid/templates/nginx-exporter-configmap.yaml
+++ b/squid/templates/nginx-exporter-configmap.yaml
@@ -19,8 +19,10 @@ data:
     
     web:
       listenAddress: ":9113"
+      {{- if .Values.nginx.tls.enabled }}
       tlsCertFile: "/etc/exporter/tls/tls.crt"
       tlsKeyFile: "/etc/exporter/tls/tls.key"
+      {{- end }}
     
     nginx:
       scrapeUri: "http://127.0.0.1:8081/stub_status"

--- a/squid/templates/nginx-servicemonitor.yaml
+++ b/squid/templates/nginx-servicemonitor.yaml
@@ -23,10 +23,15 @@ spec:
   endpoints:
     - port: metrics
       path: {{ .Values.prometheus.serviceMonitor.path }}
+      {{- if .Values.nginx.tls.enabled }}
       scheme: https
+      {{- else }}
+      scheme: http
+      {{- end }}
       interval: {{ .Values.prometheus.serviceMonitor.interval }}
       scrapeTimeout: {{ .Values.prometheus.serviceMonitor.scrapeTimeout }}
       honorLabels: true
+      {{- if .Values.nginx.tls.enabled }}
       tlsConfig:
         {{- $clusterDomain := (default "cluster.local" .Values.clusterDomain) }}
         {{- $svcFQDN := printf "%s.%s.svc.%s" .Values.nginx.name .Values.namespace.name $clusterDomain }}
@@ -34,11 +39,9 @@ spec:
         insecureSkipVerify: {{ .Values.prometheus.serviceMonitor.nginxTLS.insecureSkipVerify | default false }}
         {{- with .Values.prometheus.serviceMonitor.nginxTLS.ca }}
         ca:
-          secret:
-            name: {{ .secretName }}
-            key: {{ .key | default "ca.crt" }}
+          configMap:
+            name: {{ .configMapName }}
+            key: {{ .key | default "service-ca.crt" }}
         {{- end }}
-        {{- with .Values.prometheus.serviceMonitor.nginxTLS.caFile }}
-        caFile: {{ . }}
-        {{- end }}
+      {{- end }}
 {{- end }}

--- a/squid/templates/nginx-statefulset.yaml
+++ b/squid/templates/nginx-statefulset.yaml
@@ -147,14 +147,18 @@ spec:
             httpGet:
               path: /metrics
               port: metrics
+              {{- if .Values.nginx.tls.enabled }}
               scheme: HTTPS
+              {{- end }}
             initialDelaySeconds: 10
             periodSeconds: 30
           readinessProbe:
             httpGet:
               path: /metrics
               port: metrics
+              {{- if .Values.nginx.tls.enabled }}
               scheme: HTTPS
+              {{- end }}
             initialDelaySeconds: 5
             periodSeconds: 10
           resources:
@@ -165,9 +169,11 @@ spec:
             - name: exporter-config
               mountPath: /etc/exporter
               readOnly: true
-            - name: exporter-tls
+            {{- if .Values.nginx.tls.enabled }}
+            - name: tls
               mountPath: /etc/exporter/tls
               readOnly: true
+            {{- end }}
             - name: tmp
               mountPath: /tmp
       volumes:
@@ -194,9 +200,6 @@ spec:
         - name: exporter-config
           configMap:
             name: {{ .Values.nginx.name }}-exporter-config
-        - name: exporter-tls
-          secret:
-            secretName: {{ .Values.namespace.name }}-tls
   volumeClaimTemplates:
     - metadata:
         name: cache

--- a/squid/templates/proxy-certificate.yaml
+++ b/squid/templates/proxy-certificate.yaml
@@ -14,12 +14,7 @@ spec:
   - {{ .Values.squid.name }}
   - {{ .Values.squid.name }}.{{ .Values.namespace.name }}.svc
   - {{ .Values.squid.name }}.{{ .Values.namespace.name }}.svc.cluster.local
-  {{- if .Values.nginx.enabled }}
-  - {{ .Values.nginx.name }}
-  - {{ .Values.nginx.name }}.{{ .Values.namespace.name }}.svc
-  - {{ .Values.nginx.name }}.{{ .Values.namespace.name }}.svc.cluster.local
-  {{- end }}
-  
+
   issuerRef:
     kind: ClusterIssuer
     name: {{ .Values.namespace.name }}-ca-issuer

--- a/squid/values.schema.json
+++ b/squid/values.schema.json
@@ -459,18 +459,13 @@
                 "ca": {
                   "type": "object",
                   "properties": {
-                    "secretName": { "type": "string" },
+                    "configMapName": { "type": "string" },
                     "key": { "type": "string" }
                   },
-                  "required": ["secretName"],
+                  "required": ["configMapName"],
                   "additionalProperties": false
-                },
-                "caFile": { "type": "string" }
+                }
               },
-              "anyOf": [
-                { "required": ["ca"] },
-                { "required": ["caFile"] }
-              ],
               "additionalProperties": false
             }
           },

--- a/squid/values.yaml
+++ b/squid/values.yaml
@@ -386,16 +386,15 @@ prometheus:
       insecureSkipVerify: false
     # TLS options for nginx access-log-exporter scrape (9113). Prometheus will
     # validate the HTTPS endpoint using the provided serverName and CA.
-    # Note: TLS is always enabled for nginx access-log-exporter (not optional).
+    # Only used when nginx.tls.enabled is true. When nginx TLS is disabled,
+    # the exporter serves plain HTTP and no TLS config is needed.
     nginxTLS:
       # Leave empty to auto-derive: <service>.<namespace>.svc.<cluster-domain>
       serverName: ""
-      # If you don't have a CA handy, you can point to a Secret with ca.crt
-      ca:
-        secretName: "caching-tls"
-        # key: "ca.crt" # optional, defaults to ca.crt
-      # Alternatively, reference a mounted CA file path inside Prometheus
-      # caFile: "/etc/prometheus/configmaps/proxy-ca/ca.crt"
+      # CA ConfigMap for verifying the exporter's TLS certificate.
+      # ca:
+        # configMapName: "openshift-service-ca.crt"
+        # key: "service-ca.crt"
       # As a last resort only (not recommended), you can skip verification
       insecureSkipVerify: false
 

--- a/tests/e2e/nginx_access_log_exporter_test.go
+++ b/tests/e2e/nginx_access_log_exporter_test.go
@@ -1,7 +1,6 @@
 package e2e_test
 
 import (
-	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -43,13 +42,8 @@ var _ = Describe("NGINX Access-Log-Exporter Integration", Label("nginx", "monito
 		nginxClient = testhelpers.NewNginxClient()
 		metricsClient = &http.Client{
 			Timeout: 10 * time.Second,
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: true,
-				},
-			},
 		}
-		metricsURL = fmt.Sprintf("https://%s.%s.svc.cluster.local:9113/metrics",
+		metricsURL = fmt.Sprintf("http://%s.%s.svc.cluster.local:9113/metrics",
 			testhelpers.NginxServiceName, namespace)
 	})
 
@@ -73,15 +67,13 @@ var _ = Describe("NGINX Access-Log-Exporter Integration", Label("nginx", "monito
 			Expect(exporterContainer.Ports[0].ContainerPort).To(Equal(int32(9113)), "metrics port should be 9113")
 			Expect(exporterContainer.Ports[0].Name).To(Equal("metrics"), "port should be named 'metrics'")
 
-			// Verify volume mounts for config and TLS
+			// Verify volume mounts for config (TLS mount is only present when nginx.tls.enabled=true)
 			volumeMounts := make(map[string]string)
 			for _, vm := range exporterContainer.VolumeMounts {
 				volumeMounts[vm.Name] = vm.MountPath
 			}
 			Expect(volumeMounts).To(HaveKey("exporter-config"), "should mount exporter config")
 			Expect(volumeMounts["exporter-config"]).To(Equal("/etc/exporter"), "config should be at /etc/exporter")
-			Expect(volumeMounts).To(HaveKey("exporter-tls"), "should mount TLS certificates")
-			Expect(volumeMounts["exporter-tls"]).To(Equal("/etc/exporter/tls"), "TLS certs should be at /etc/exporter/tls")
 		})
 
 		It("should expose metrics endpoint through service", func() {

--- a/tests/e2e/nginx_https_test.go
+++ b/tests/e2e/nginx_https_test.go
@@ -2,6 +2,7 @@ package e2e_test
 
 import (
 	"crypto/tls"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -54,6 +55,17 @@ var _ = Describe("Nginx HTTPS Tests", Label("nginx"), Ordered, Serial, func() {
 
 		httpsClient, err = testhelpers.NewNginxHTTPSClient(caCert)
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should serve metrics over HTTPS when TLS is enabled", func() {
+		metricsURL := fmt.Sprintf("https://%s.%s.svc.cluster.local:9113/metrics",
+			testhelpers.NginxServiceName, namespace)
+		resp, err := httpsClient.Get(metricsURL)
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		Expect(resp.TLS).NotTo(BeNil(), "TLS connection state should not be nil")
 	})
 
 	It("should serve HTTPS requests", func() {

--- a/tests/helm/helpers_test.go
+++ b/tests/helm/helpers_test.go
@@ -71,3 +71,13 @@ func extractSquidHeadlessServiceSection(helmOutput string) string {
 func extractSquidConfigMapSection(helmOutput string) string {
 	return extractSection(helmOutput, "# Source: squid/templates/configmap.yaml")
 }
+
+// extractNginxExporterConfigMapSection extracts just the nginx exporter configmap YAML for precise testing
+func extractNginxExporterConfigMapSection(helmOutput string) string {
+	return extractSection(helmOutput, "# Source: squid/templates/nginx-exporter-configmap.yaml")
+}
+
+// extractNginxServiceMonitorSection extracts just the nginx servicemonitor YAML for precise testing
+func extractNginxServiceMonitorSection(helmOutput string) string {
+	return extractSection(helmOutput, "# Source: squid/templates/nginx-servicemonitor.yaml")
+}

--- a/tests/helm/nginx_template_test.go
+++ b/tests/helm/nginx_template_test.go
@@ -453,6 +453,91 @@ var _ = Describe("Helm Template Nginx Configuration", func() {
 			configMap := extractNginxConfigMapSection(output)
 			Expect(configMap).To(ContainSubstring("listen 8443 ssl"), "ConfigMap should have HTTPS server block")
 		})
+
+		It("should configure access-log-exporter for HTTP when TLS is disabled", func() {
+			output, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{
+				Nginx: &testhelpers.NginxValues{
+					Enabled: true,
+					Upstream: &testhelpers.NginxUpstreamValues{
+						URL: "http://backend:8080",
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			statefulSet := extractNginxStatefulSetSection(output)
+			Expect(statefulSet).NotTo(ContainSubstring("mountPath: /etc/exporter/tls"), "Exporter should not mount TLS when TLS disabled")
+
+			serviceMonitor := extractNginxServiceMonitorSection(output)
+			Expect(serviceMonitor).To(ContainSubstring("scheme: http"), "ServiceMonitor should use HTTP scheme when TLS disabled")
+			Expect(serviceMonitor).NotTo(ContainSubstring("tlsConfig"), "ServiceMonitor should not have tlsConfig when TLS disabled")
+
+			configMap := extractNginxExporterConfigMapSection(output)
+			Expect(configMap).NotTo(ContainSubstring("tlsCertFile"), "Exporter config should not have tlsCertFile when TLS disabled")
+			Expect(configMap).NotTo(ContainSubstring("tlsKeyFile"), "Exporter config should not have tlsKeyFile when TLS disabled")
+		})
+
+		It("should configure access-log-exporter for HTTPS using nginx TLS secret when TLS is enabled", func() {
+			output, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{
+				Nginx: &testhelpers.NginxValues{
+					Enabled: true,
+					Upstream: &testhelpers.NginxUpstreamValues{
+						URL: "http://backend:8080",
+					},
+					Service: &testhelpers.NginxServiceValues{
+						Port: 443,
+					},
+					TLS: &testhelpers.NginxTLSValues{
+						Enabled:    true,
+						SecretName: "my-nginx-tls",
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			statefulSet := extractNginxStatefulSetSection(output)
+			Expect(statefulSet).To(ContainSubstring("mountPath: /etc/exporter/tls"), "Exporter should mount TLS volume")
+			Expect(statefulSet).NotTo(ContainSubstring("exporter-tls"), "Should not have separate exporter-tls volume")
+
+			configMap := extractNginxExporterConfigMapSection(output)
+			Expect(configMap).To(ContainSubstring("tlsCertFile"), "Exporter config should have tlsCertFile when TLS enabled")
+			Expect(configMap).To(ContainSubstring("tlsKeyFile"), "Exporter config should have tlsKeyFile when TLS enabled")
+		})
+
+		It("should configure ServiceMonitor with CA ConfigMap when TLS is enabled", func() {
+			output, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{
+				Nginx: &testhelpers.NginxValues{
+					Enabled: true,
+					Upstream: &testhelpers.NginxUpstreamValues{
+						URL: "http://backend:8080",
+					},
+					Service: &testhelpers.NginxServiceValues{
+						Port: 443,
+					},
+					TLS: &testhelpers.NginxTLSValues{
+						Enabled:    true,
+						SecretName: "my-nginx-tls",
+					},
+				},
+				Prometheus: &testhelpers.PrometheusValues{
+					ServiceMonitor: &testhelpers.ServiceMonitorValues{
+						NginxTLS: &testhelpers.NginxTLSMonitorValues{
+							CA: &testhelpers.CAValues{
+								ConfigMapName: "openshift-service-ca.crt",
+								Key:           "service-ca.crt",
+							},
+						},
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			serviceMonitor := extractNginxServiceMonitorSection(output)
+			Expect(serviceMonitor).To(ContainSubstring("scheme: https"), "ServiceMonitor should use HTTPS scheme")
+			Expect(serviceMonitor).To(ContainSubstring("configMap:"), "ServiceMonitor should reference CA via configMap")
+			Expect(serviceMonitor).To(ContainSubstring("name: openshift-service-ca.crt"), "ServiceMonitor should reference correct ConfigMap name")
+			Expect(serviceMonitor).To(ContainSubstring("key: service-ca.crt"), "ServiceMonitor should reference correct key")
+		})
 	})
 
 	Describe("Nginx Service Configuration", func() {

--- a/tests/testhelpers/proxy_test_helpers.go
+++ b/tests/testhelpers/proxy_test_helpers.go
@@ -407,6 +407,28 @@ type SquidHelmValues struct {
 	VolumeMounts       []corev1.VolumeMount      `json:"volumeMounts,omitempty"`
 	Nginx              *NginxValues              `json:"nginx,omitempty"`
 	Service            *ServiceValues            `json:"service,omitempty"`
+	Prometheus         *PrometheusValues         `json:"prometheus,omitempty"`
+}
+
+// PrometheusValues holds Prometheus monitoring configuration
+type PrometheusValues struct {
+	ServiceMonitor *ServiceMonitorValues `json:"serviceMonitor,omitempty"`
+}
+
+// ServiceMonitorValues holds ServiceMonitor configuration
+type ServiceMonitorValues struct {
+	NginxTLS *NginxTLSMonitorValues `json:"nginxTLS,omitempty"`
+}
+
+// NginxTLSMonitorValues holds TLS config for the nginx ServiceMonitor endpoint
+type NginxTLSMonitorValues struct {
+	CA *CAValues `json:"ca,omitempty"`
+}
+
+// CAValues holds CA ConfigMap reference for ServiceMonitor TLS verification
+type CAValues struct {
+	ConfigMapName string `json:"configMapName,omitempty"`
+	Key           string `json:"key,omitempty"`
 }
 
 // parseImageReference extracts repository and tag from an image reference


### PR DESCRIPTION
The access-log-exporter sidecar was using the shared caching-tls cert-manager certificate (squid's PKI) for its metrics endpoint. This coupled two unrelated services under the same certificate identity and required PR #769's workaround of adding nginx DNS SANs to the squid certificate.

The exporter TLS is now conditional on nginx.tls.enabled. When enabled, the exporter uses the same TLS secret as the nginx container since both are accessed through the same service. When disabled, the exporter serves plain HTTP. This eliminates the dependency on caching-tls and keeps squid and nginx PKI chains fully separate.

Assisted-by: Claude Opus 4.6

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [x] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
