### PR TITLE
docs(README): refactor README and extract detailed docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1109 +1,237 @@
 # Squid Proxy for Kubernetes
 
-This repository contains a Helm chart for deploying a Squid HTTP proxy server in Kubernetes. The chart is designed to be self-contained and deploys into a dedicated `caching` namespace.
+A Helm chart for deploying a Squid HTTP proxy in Kubernetes, with SSL-bump support, caching, and Prometheus monitoring. Deploys into a dedicated `caching` namespace.
 
-## Development Prerequisites
+## Prerequisites
 
-Increase the `inotify` resource limits to avoid Kind issues related to
-[too many open files in](https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files).
-To increase the limits temporarily, run the following commands:
+> **Quick option**: Use the [dev container](.devcontainer/) for a zero-setup environment with all tools pre-installed.
+
+For manual setup, you need:
+
+| Tool | Version | Notes |
+|------|---------|-------|
+| Go | 1.25+ | Required for Mage |
+| Podman | Latest | Mage automation uses Podman explicitly |
+| Kind | Latest | Kubernetes in Docker/Podman |
+| kubectl | Latest | Kubernetes CLI |
+| Helm | 3.x | Chart deployment |
+| Mage | 1.16+ | `go install github.com/magefile/mage@latest` |
+
+**Critical for Kind**: Increase inotify limits to avoid [file watcher issues](https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files):
 
 ```bash
 sudo sysctl fs.inotify.max_user_watches=1048576
 sudo sysctl fs.inotify.max_user_instances=1024
 ```
 
-When using Dev Containers, the automation will fetch those values, and if it's
-successful, it will verify them against the limits above and fail container
-initialization if either value is too low.
-
-### Option 1: Manual Installation
-
-- [gcc](https://gcc.gnu.org/)
-- [Go](https://golang.org/doc/install) 1.25 or later
-- [Docker](https://docs.docker.com/get-docker/) or [Podman](https://podman.io/getting-started/installation)
-- [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (Kubernetes in Docker)
-- [kubectl](https://kubernetes.io/docs/tasks/tools/)
-- [Helm](https://helm.sh/docs/intro/install/) v3.x
-- [Mage](https://magefile.org/) (for automation - `go install github.com/magefile/mage@latest`)
-- [mirrord](https://mirrord.dev/docs/overview/quick-start/) (for local development with cluster network access - optional but recommended)
-
-#### Debug Symbols (Required for Go Debugging)
-
-Install the following debug symbols to enable proper debugging of Go applications:
-
-```bash
-# Enable debug repositories and install debug symbols
-sudo dnf install -y dnf-plugins-core
-sudo dnf --enablerepo=fedora-debuginfo,updates-debuginfo install -y \
-    glibc-debuginfo \
-    gcc-debuginfo \
-    libgcc-debuginfo
-```
-
-### Option 2: Development Container (Automated)
-
-This repository includes a dev container configuration that provides a consistent development environment with all prerequisites pre-installed. To use it, you need the following on your local machine:
-
-1. **Podman**: The dev container is based on Podman. Ensure it is installed on your system.
-2. **Docker alias for Podman**: The VSCode Dev Containers extension relies on using the "docker" command, so the podman command needs to be aliased to "docker". You can either:
-   - **Fedora Workstation**: Install the `podman-docker` package: `sudo dnf install podman-docker`
-   - **Fedora Silverblue/Kinoite**: Install via rpm-ostree: `sudo rpm-ostree install podman-docker` (requires reboot)
-   - **Manual alias** (any system): `sudo ln -s /usr/bin/podman /usr/local/bin/docker`
-3. **VS Code with Dev Containers extension**: For the best experience, use Visual Studio Code with the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
-4. **Running Podman Socket**: The dev container connects to your local Podman socket. Make sure the user service is running before you start the container:
-
-    ```bash
-    systemctl --user start podman.socket
-    ```
-
-    To enable the socket permanently so it starts on boot, you can run:
-
-    ```bash
-    systemctl --user enable --now podman.socket
-    ```
-
-Once these prerequisites are met, you can open this folder in VS Code and use the "Reopen in Container" command to launch the environment with all tools pre-configured.
-
-## Hermetic Builds
-
-This project uses hermetic (network-isolated) builds in Konflux CI to ensure reproducible, supply-chain-secure container images. Dependencies are pre-fetched and version-locked before builds run with network access disabled.
-
-Maintainers should consult [HERMETIC-BUILDS.md](./HERMETIC-BUILDS.md) for guidance on updating dependency lock files.
+For detailed setup instructions, see [docs/development.md](docs/development.md).
 
 ## Quick Start
 
-### Using automation
-
-This repository includes complete automation for setting up your local development and testing environment. Use this approach for the easiest setup:
-
 ```bash
-# Set up the complete local dev/test environment automatically
+# Full setup: build, deploy, test
 mage all
 ```
 
-This single command will:
-- Create the 'caching' kind cluster (or connect to existing)
-- Build the consolidated squid container image (with integrated squid-exporter and per-site exporter)
-- Load the image into the cluster
-- Deploy the Helm chart with all dependencies
-- Verify the deployment status
+This single command creates a Kind cluster, builds images, deploys the Helm chart, and runs tests.
 
-#### Individual Components
+### Essential Commands
 
-You can also run individual components:
+| Command | Description |
+|---------|-------------|
+| `mage all` | Complete setup and test |
+| `mage clean` | Remove everything |
+| `mage -l` | List all commands |
 
-```bash
-# Cluster management
-mage kind:up          # Create/connect to cluster
-mage kind:status      # Check cluster status
-mage kind:down        # Remove cluster
-mage kind:upClean     # Force recreate cluster
+### Individual Components
 
-# Image management
-mage build:squid               # Build squid image (squid + squid-exporter + per-site-exporter + store-id + icap-server)
-mage build:accessLogExporter   # Build access-log-exporter image (for use as sidecar with nginx monitoring)
-mage build:loadSquid           # Load squid image into cluster
-mage build:loadAccessLogExporter # Load access-log-exporter image into cluster
+| Command | Description |
+|---------|-------------|
+| `mage kind:up` | Create Kind cluster |
+| `mage kind:down` | Delete Kind cluster |
+| `mage build:squid` | Build Squid image |
+| `mage build:loadSquid` | Load image into cluster |
+| `mage squidHelm:up` | Deploy Helm chart |
+| `mage squidHelm:status` | Check deployment |
+| `mage test:unit` | Unit tests (no cluster) |
+| `mage test:cluster` | E2E tests with mirrord |
 
-# Deployment management
-mage squidHelm:up     # Deploy/upgrade helm chart
-mage squidHelm:status # Check deployment status
-mage squidHelm:down   # Remove deployment
-mage squidHelm:upClean # Force redeploy
+## Hermetic Builds
 
-# Testing
-mage test:cluster     # Run tests with mirrord cluster networking
-
-# Complete cleanup
-mage clean           # Remove everything (cluster, images, etc.)
-```
-
-#### List All Available Commands
-
-```bash
-# See all available automation commands
-mage -l
-```
-
-### Manual Setup (Advanced)
-
-If you prefer manual control or want to understand the individual steps:
-
-#### 1. Create a kind Cluster
-
-```bash
-# Create a new kind cluster (or use: mage kind:up)
-kind create cluster --name caching
-
-# Verify the cluster is running
-kubectl cluster-info --context kind-caching
-```
-
-#### 2. Build and Load the Squid Container Image
-
-The Containerfile has multiple stages (squid and access-log-exporter). Use `--target squid` to build the Squid image:
-
-```bash
-# Build the squid image (or use: mage build:squid)
-podman build --target squid -t localhost/konflux-ci/squid:latest -f Containerfile .
-
-# Load the image into kind (or use: mage build:loadSquid)
-kind load image-archive --name caching <(podman save localhost/konflux-ci/squid:latest)
-```
-
-To build the access-log-exporter image (minimal image for use as sidecar with NGINX) instead:
-
-```bash
-# Build the access-log-exporter image (or use: mage build:accessLogExporter)
-podman build --target access-log-exporter -t localhost/konflux-ci/access-log-exporter:latest -f Containerfile .
-```
-
-#### 3. Build and Load the "Testing" Container Image
-
-```bash
-# Build the container image (or use: mage build:squid)
-podman build -t localhost/konflux-ci/squid-test:latest -f test.Containerfile .
-
-# Load the image into kind (or use: mage build:loadSquid)
-kind load image-archive --name caching <(podman save localhost/konflux-ci/squid-test:latest)
-```
-
-#### 4. Deploy Squid with Helm
-
-```bash
-# Install the Helm chart (or use: mage squidHelm:up)
-helm install squid ./squid --set environment=dev
-
-# Verify deployment (or use: mage squidHelm:status)
-kubectl get pods -n caching
-kubectl get svc -n caching
-```
-
-By default:
-- The cert-manager and trust-manager dependencies will be deployed into the cert-manager namespace.
-If you wish to disable these deployments, you can do so by setting the parameter `--set installCertManagerComponents=false`
-
-- The resources (issuer, certificate, bundle) are created
-if you wish to disable the resources creation, you can do so by setting the parameter `--set selfsigned-bundle.enabled=false`
-
-#### Examples:
-
-  ```bash
-  # Install squid + cert-manager + trust-manager + resources
-  helm install squid ./squid
-  ```
-
-  ```bash
-  # Install squid without cert-manager, without trust-manager and without creating resources
-  helm install squid ./squid --set installCertManagerComponents=false --set selfsigned-bundle.enabled=false
-  ```
-
-  ```bash
-  # Install squid + cert-manager + trust-manager without creating resources
-  helm install squid ./squid --set selfsigned-issuer.enabled=false
-  ```
-
-  ```bash
-  # Install squid without cert-manager, without trust-manager + create resources
-  helm install squid ./squid --set installCertManagerComponents=false
-  ```
+This project uses hermetic (network-isolated) builds in Konflux CI. See [HERMETIC-BUILDS.md](./HERMETIC-BUILDS.md) for guidance on updating dependency lock files.
 
 ## Using the Proxy
 
 ### From Within the Cluster
 
-The Squid proxy is accessible at:
+```bash
+# Same namespace
+curl --proxy http://squid:3128 http://httpbin.org/ip
 
-- **Same namespace**: `http://squid:3128`
-- **Cross-namespace**: `http://squid.caching.svc.cluster.local:3128`
+# Cross-namespace
+curl --proxy http://squid.caching.svc.cluster.local:3128 http://httpbin.org/ip
+```
 
-#### Example: Testing with a curl pod
+#### Testing with a curl Pod
 
 ```bash
-# Create a test pod for testing the proxy (HTTP)
-kubectl run test-client --image=curlimages/curl:latest --rm -it -- \
+# Test HTTP proxy
+kubectl run test-curl --image=curlimages/curl:latest --rm -it -- \
     sh -c 'curl --proxy http://squid.caching.svc.cluster.local:3128 http://httpbin.org/ip'
 
-# Create a test pod for testing SSL-Bump (HTTPS)
-kubectl run test-client-ssl --image=curlimages/curl:latest --rm -it -- \
+# Test HTTPS via SSL-bump (-k to skip cert verification)
+kubectl run test-curl-ssl --image=curlimages/curl:latest --rm -it -- \
     sh -c 'curl -k --proxy http://squid.caching.svc.cluster.local:3128 https://httpbin.org/ip'
 ```
 
-### From Your Local Machine (for testing)
+### From Your Local Machine
 
 ```bash
-# Forward the proxy port to your local machine
-export POD_NAME=$(kubectl get pods --namespace caching -l "app.kubernetes.io/name=squid,app.kubernetes.io/instance=squid" -o jsonpath="{.items[0].metadata.name}")
-kubectl --namespace caching port-forward $POD_NAME 3128:3128
-
-# In another terminal, test the proxy (HTTP)
+kubectl port-forward -n caching svc/squid 3128:3128
 curl --proxy http://127.0.0.1:3128 http://httpbin.org/ip
 ```
 
+## Helm Configuration
+
+```bash
+# Full install with cert-manager (default)
+helm install squid ./squid
+
+# Without deploying cert-manager (requires cert-manager already installed on the cluster)
+# Note: Certificate resources are still created — cert-manager must be present
+helm install squid ./squid --set installCertManagerComponents=false
+
+# Disable TLS certificate resources (cert-manager still deployed)
+helm install squid ./squid --set installCertManagerComponents=false --set selfsigned-bundle.enabled=false
+
+# Local development
+helm install squid ./squid --set environment=dev --set nginx.enabled=true
+```
+
+### Key Values
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `environment` | `release` | `dev` (local images), `prerelease`, `release` (Quay) |
+| `installCertManagerComponents` | `true` | Deploy cert-manager and trust-manager |
+| `selfsigned-bundle.enabled` | `true` | Create trust bundle resource |
+| `selfsigned-certificate.enabled` | `true` | Create certificate resources |
+| `squidExporter.enabled` | `true` | Enable Prometheus metrics |
+| `nginx.enabled` | `false` | Deploy NGINX reverse proxy |
 
 ## Testing
 
-This repository includes comprehensive end-to-end tests to validate the Squid proxy deployment and HTTP caching functionality. The test suite uses [Ginkgo](https://onsi.github.io/ginkgo/) for behavior-driven testing and [mirrord](https://mirrord.dev/) for local development with cluster network access.
-
-### Quick Start - Run All Tests
-
 ```bash
-# Complete test setup and execution (recommended)
+# Full test suite via Helm
 mage all
-```
 
-In this mode tests are invoked by Helm via `helm test`.
+# E2E tests with local debugging (mirrord)
+mage test:cluster
 
-**Note**: When running `helm test` directly (not through `mage all`), you must specify a timeout of at least 420 seconds (7 minutes) using the `--timeout` flag:
+# Filter tests
+GINKGO_LABEL_FILTER='!external-deps' mage test:cluster
 
-```bash
+# Direct helm test (requires explicit timeout)
 helm test squid --timeout=420s
 ```
 
-The default Helm test timeout is 5 minutes (300 seconds), which may not be sufficient for all tests to complete.
+The test suite uses [Ginkgo](https://onsi.github.io/ginkgo/) with [mirrord](https://mirrord.dev/) for cluster network access during local development.
 
-### Local Development Testing with Mirrord
+For VS Code debugging, test contributions, and advanced options, see [docs/testing.md](docs/testing.md).
 
-For local development and debugging, use mirrord to run tests with cluster network access:
+## Monitoring
 
-```bash
-# Setup test environment
-mage squidHelm:up
+Prometheus monitoring is enabled by default with two exporters:
 
-# Run tests locally with cluster network access using the number of replicas defined in the values file
-mage test:cluster
-
-# Run tests locally with cluster network access using 3 replicas
-mage test:clusterMultiReplica
-```
-
-This uses mirrord to "steal" network connections from a target pod and runs
-the test locally (outside of the Kind cluster) with Ginkgo. This allows for
-local debugging without rebuilding test containers
-
-### Controlling Which Tests Are Executed
-
-Use the `GINKGO_LABEL_FILTER` environment variable to skip certain tests.
-For syntax details, see the Ginkgo documentation for the `--label-filter` argument.
-
-For example, use the following filter to skip all tests with a dependency on external services.
-```bash
-# When running via `helm test`
-GINKGO_LABEL_FILTER='!external-deps' mage all
-
-# When running locally with mirrord
-GINKGO_LABEL_FILTER='!external-deps' mage test:cluster
-```
-
-### VS Code Integration
-
-The repository includes complete VS Code configuration for Ginkgo testing:
-
-#### Debug Configurations
-
-Use VS Code's debug panel to run tests with breakpoints:
-
-1. **Debug Ginkgo E2E Tests**: Run all E2E tests with debugging
-2. **Debug Ginkgo Tests (Current File)**: Debug tests in the currently open file
-3. **Run Ginkgo Tests with Coverage**: Generate test coverage reports
-
-#### Tasks and Commands
-
-Available VS Code tasks (Ctrl+Shift+P → "Tasks: Run Task"):
-
-- **Setup Test Environment**: Runs `mage all` to prepare everything
-- **Run Ginkgo E2E Tests**: Execute the full test suite
-- **Clean Test Environment**: Clean up all resources
-- **Run Focused Ginkgo Tests**: Run specific test patterns
-
-### Contributing to Tests
-
-When adding new tests:
-
-1. **Use test helpers**: Leverage `tests/testhelpers/` for common operations
-2. **Follow Ginkgo patterns**: Use `Describe`, `Context`, `It` for clear test structure
-3. **Add cache-busting**: Use unique URLs to prevent test interference
-4. **Verify cleanup**: Ensure tests clean up resources properly
-5. **Update VS Code config**: Add debug configurations for new test files
-
-## Prometheus Monitoring
-
-This chart includes comprehensive Prometheus monitoring capabilities through:
-
-- Integrated upstream [squid-exporter](https://github.com/boynux/squid-exporter) for standard Squid metrics
-- A per-site exporter that parses Squid access logs (via STDOUT piping) to emit per-host request metrics
-
-Both exporters are bundled into the single Squid container image. The monitoring system provides detailed metrics about Squid's operational status, including:
-
-- **Liveness**: Squid service information and connection status
-- **Bandwidth Usage**: Client HTTP and Server HTTP traffic metrics
-- **Hit/Miss Rates**: Cache performance metrics (general and detailed)
-- **Storage Utilization**: Cache information and memory usage
-- **Service Times**: Response times for different operations
-- **Connection Information**: Active connections and request details
-
-### Enabling Monitoring
-
-Monitoring is enabled by default. To customize or disable it:
-
-```yaml
-# In values.yaml or via --set flags
-squidExporter:
-  enabled: true  # Set to false to disable
-  port: 9301
-  metricsPath: "/metrics"
-  extractServiceTimes: "true"  # Enables detailed service time metrics
-  resources:
-    requests:
-      cpu: 10m
-      memory: 16Mi
-    limits:
-      cpu: 100m
-      memory: 64Mi
-```
-
-Per-site exporter (enabled by default):
-
-```yaml
-# In values.yaml or via --set flags
-perSiteExporter:
-  enabled: true
-  port: 9302
-  metricsPath: "/metrics"
-```
-
-### Prometheus Integration
-
-#### Option 1: Prometheus Operator (Recommended)
-
-If you're using Prometheus Operator, the chart automatically creates a ServiceMonitor:
-
-```yaml
-prometheus:
-  serviceMonitor:
-    enabled: true
-    interval: 30s
-    scrapeTimeout: 10s
-    namespace: ""  # Leave empty to use the same namespace as the app
-```
-
-When enabled, the ServiceMonitor exposes endpoints for both exporters: `9301` (standard) and `9302` (per-site).
-
-#### Option 2: Manual Prometheus Configuration
-
-**ServiceMonitor CRD Included:**
-
-The chart includes the ServiceMonitor CRD in the `crds/` directory, so it will be automatically installed by Helm when the chart is deployed. This follows the same pattern as the cert-manager and trust-manager CRDs.
-
-If you don't want ServiceMonitor functionality, you can disable it:
-```bash
-helm install squid ./squid --set prometheus.serviceMonitor.enabled=false
-```
-
-**For non-Prometheus Operator setups**, disable ServiceMonitor and use manual Prometheus configuration:
-
-For manual Prometheus setup (if you have an existing Prometheus instance), add this scrape configuration to your external Prometheus configuration:
-
-```yaml
-scrape_configs:
-  - job_name: 'squid-proxy'
-    static_configs:
-      - targets: ['squid.caching.svc.cluster.local:9301']
-    scrape_interval: 30s
-    metrics_path: '/metrics'
-```
-
-**Complete example**: See `docs/prometheus-config-example.yaml` in this repository for a full Prometheus configuration file.
-
-### Available Metrics
-
-The monitoring system provides numerous metrics including:
-
-#### Standard Squid Metrics (Port 9301)
-
-- `squid_client_http_requests_total`: Total client HTTP requests
-- `squid_client_http_hits_total`: Total client HTTP hits
-- `squid_client_http_errors_total`: Total client HTTP errors
-- `squid_server_http_requests_total`: Total server HTTP requests
-- `squid_cache_memory_bytes`: Cache memory usage
-- `squid_cache_disk_bytes`: Cache disk usage
-- `squid_service_times_seconds`: Service times for different operations
-- `squid_up`: Squid availability status
-
-#### Per-site Metrics (Port 9302)
-
-- `squid_site_requests_total{host="<hostname>"}`: Total requests per origin host
-- `squid_site_hits_total{host="<hostname>"}`: Cache hits per host
-- `squid_site_misses_total{host="<hostname>"}`: Cache misses per host
-- `squid_site_bytes_total{host="<hostname>"}`: Bytes transferred per host
-- `squid_site_hit_ratio{host="<hostname>"}`: Hit ratio gauge per host
-- `squid_site_response_time_seconds{host="<hostname>",le="..."}`: Response time histogram per host
-
-### Accessing Metrics
-
-#### Via Port Forward
+| Port | Exporter | Metrics |
+|------|----------|---------|
+| 9301 | squid-exporter | Cache stats, request counts, service times |
+| 9302 | per-site-exporter | Per-host request metrics |
 
 ```bash
-# Forward the standard squid-exporter metrics port
+# View metrics
 kubectl port-forward -n caching svc/squid 9301:9301
-
-# View standard metrics in your browser or with curl
 curl http://localhost:9301/metrics
 ```
 
-Per-site exporter metrics:
-
-```bash
-# Forward the per-site exporter metrics port
-kubectl port-forward -n caching svc/squid 9302:9302
-
-# View per-site metrics
-curl http://localhost:9302/metrics
-```
-
-#### Via Service
-
-The metrics are exposed on the service:
-
-```bash
-# Standard squid-exporter metrics (from within the cluster)
-curl http://squid.caching.svc.cluster.local:9301/metrics
-```
-
-Per-site exporter metrics (from within the cluster):
-
-```bash
-curl http://squid.caching.svc.cluster.local:9302/metrics
-```
-
-### Troubleshooting Metrics
-
-#### No Metrics Appearing
-
-1. **Check if the squid container is running**:
-   ```bash
-   kubectl get pods -n caching
-   kubectl logs -n caching deployment/squid -c squid-exporter
-   ```
-
-2. **Verify cache manager access**:
-   ```bash
-   # Test from within the pod
-   kubectl exec -n caching deployment/squid -c squid-exporter -- \
-     curl -s http://localhost:3128/squid-internal-mgr/info
-   ```
-
-3. **Check ServiceMonitor (if using Prometheus Operator)**:
-   ```bash
-   kubectl get servicemonitor -n caching
-   kubectl describe servicemonitor -n caching squid
-   ```
-
-#### Metrics Access Denied
-
-If you see "access denied" errors, ensure that the squid configuration allows localhost manager access. The default configuration should work, but if you've modified the configuration in `squid/templates/configmap.yaml`, make sure these lines are present:
-
-```
-http_access allow localhost manager
-http_access deny manager
-```
+For detailed configuration, see [docs/monitoring.md](docs/monitoring.md).
 
 ## Troubleshooting
 
+### Quick Diagnostics
+
+```bash
+kubectl get pods -n caching
+kubectl logs -n caching -l app.kubernetes.io/name=squid -c squid
+mage squidHelm:status
+```
+
 ### Common Issues
 
-#### 1. Cluster Already Exists Error
-
-**Symptom**: When trying to create a kind cluster, you see:
-```
-ERROR: failed to create cluster: node(s) already exist for a cluster with the name "kind"
-```
-
-**Solution**: Either use the existing cluster or delete it first:
-```bash
-# Option 1: Use existing cluster (recommended for dev container users)
-kind export kubeconfig --name caching
-kubectl cluster-info --context kind-caching
-
-# Option 2: Delete and recreate
-kind delete cluster --name caching
-kind create cluster --name caching
-```
-
-#### 2. kubectl Access Issues (Dev Container)
-
-**Symptom**: `kubectl` commands fail with connection errors when using the dev container
-
-**Solution**: Configure kubectl access to the existing cluster:
-```bash
-# Check current context
-kubectl config current-context
-
-# List available contexts
-kubectl config get-contexts
-
-# Export kubeconfig for existing cluster
-kind export kubeconfig --name caching
-
-# Switch to the kind context if needed
-kubectl config use-context kind-caching
-
-# Test connectivity
-kubectl get pods --all-namespaces
-```
-
-#### 3. Image Pull Errors
-
-**Symptom**: Pod shows `ImagePullBackOff` or `ErrImagePull`
-
-**Solution**: Ensure the image is loaded into kind:
-```bash
-# Check if image is loaded
-docker exec -it caching-control-plane crictl images | grep squid
-
-# If missing, reload the image
-kind load image-archive --name caching <(podman save localhost/konflux-ci/squid:latest)
-```
-
-#### 4. Permission Denied Errors
-
-**Symptom**: Pod logs show `Permission denied` when accessing `/etc/squid/squid.conf`
-
-**Solution**: This is usually resolved by the correct security context in our chart. Verify:
-```bash
-kubectl describe pod -n caching $(kubectl get pods -n caching -o name | head -1)
-```
-
-Look for:
-- `runAsUser: 1001`
-- `runAsGroup: 0`
-- `fsGroup: 0`
-
-#### 5. Namespace Already Exists Errors
-
-**Symptom**: Helm install fails with namespace ownership errors
-
-**Solution**: Clean up and reinstall:
-```bash
-helm uninstall squid 2>/dev/null || true
-kubectl delete namespace caching 2>/dev/null || true
-# Wait a few seconds for cleanup
-sleep 5
-helm install squid ./squid
-```
-
-#### 6. Connection Refused from Pods
-
-**Symptom**: Pods cannot connect to the proxy
-
-**Solution**: Check if the pod network CIDR is covered by Squid's ACLs:
-```bash
-# Check cluster CIDR
-kubectl cluster-info dump | grep -i cidr
-
-# Verify it's covered by the localnet ACLs in squid.conf
-# Default ACLs cover: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
-```
-
-#### 7. Test Pod IP Not Available
-
-**Symptom**: Tests fail with "POD_IP environment variable not set"
-
-**Solution**: Ensure downward API is configured (automatically handled by Helm chart):
-```bash
-kubectl describe pod -n caching <test-pod-name>
-```
-
-#### 8. Mirrord Connection Issues
-
-**Symptom**: `mage test:cluster` fails with mirrord connection errors
-
-**Solution**: Verify mirrord infrastructure is deployed and working:
-```bash
-# Verify mirrord target pod is ready
-kubectl get pods -n caching -l app.kubernetes.io/component=mirrord-target
-
-# Check mirrord target pod logs
-kubectl logs -n caching mirrord-test-target
-
-# Verify mirrord configuration
-cat .mirrord/mirrord.json
-
-# Ensure mirrord is installed
-which mirrord
-```
-
-#### 9. Test Failures
-
-**Symptom**: Tests fail unexpectedly or show connection issues
-
-**Solution**: Debug test execution and cluster state:
-```bash
-# Run tests with verbose output
-mage test:cluster  # Check output for detailed error messages
-
-# Verify cluster state before running tests
-mage squidHelm:status
-
-# Check if all pods are running
-kubectl get pods -n caching
-
-# Verify proxy connectivity manually
-kubectl run debug --image=curlimages/curl:latest --rm -it -- \
-  curl -v --proxy http://squid.caching.svc.cluster.local:3128 http://httpbin.org/ip
-
-# View test logs from helm tests
-kubectl logs -n caching -l app.kubernetes.io/component=test
-```
-
-#### 10. Working with Existing kind Clusters (Dev Container Users)
-
-**Symptom**: You're using the dev container and have an existing kind cluster with a different name
-
-**Solution**: Either use the existing cluster or create the expected one:
-```bash
-# Option 1: Check what clusters exist
-kind get clusters
-
-# Option 2: Export kubeconfig for existing cluster (if using default 'kind' cluster)
-kind export kubeconfig --name kind
-kubectl config use-context kind-kind
-
-# Option 3: Create the expected 'caching' cluster for consistency with automation
-kind create cluster --name caching
-```
-
-### Debugging Commands
-
-```bash
-# Check pod status
-kubectl get pods -n caching
-
-# View pod logs
-kubectl logs -n caching deployment/squid
-
-# Test connectivity from within cluster
-kubectl run debug --image=curlimages/curl:latest --rm -it -- curl -v --proxy http://squid.caching.svc.cluster.local:3128 http://httpbin.org/ip
-
-# Check service endpoints
-kubectl get endpoints -n caching
-
-# Verify test infrastructure (when running tests)
-kubectl get pods -n caching -l app.kubernetes.io/component=mirrord-target
-kubectl get pods -n caching -l app.kubernetes.io/component=test
-
-# View test logs from helm tests
-kubectl logs -n caching -l app.kubernetes.io/component=test
-```
-
-### Health Checks
-
-The deployment includes TCP-based liveness and readiness probes on port 3128. You may see health check entries in the access logs as:
-
-```
-error:transaction-end-before-headers
-```
-
-This is normal - Kubernetes is performing TCP health checks without sending complete HTTP requests.
-
-## Testing with Squid Proxy Monitoring Integration
-
-This section provides step-by-step testing instructions for the Squid proxy monitoring integration.
-
-### Complete Monitoring Integration Tests
-
-#### 1. Pre-Test Setup
-
-##### 1.1 Verify Cluster Connectivity
-```bash
-# Test basic cluster access
-kubectl cluster-info
-
-# Show current context
-kubectl config current-context
-
-# Verify nodes are ready
-kubectl get nodes
-```
-
-**Expected Result**: Cluster information displays correctly with no errors.
-
-##### 1.2 Install Prometheus Operator (if needed)
-```bash
-# Check if ServiceMonitor CRD exists
-kubectl get crd servicemonitors.monitoring.coreos.com
-
-# If the CRD doesn't exist, install Prometheus Operator
-if ! kubectl get crd servicemonitors.monitoring.coreos.com &> /dev/null; then
-  echo "Installing Prometheus Operator..."
-  kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/main/bundle.yaml
-
-  # Wait for CRDs to be established
-  kubectl wait --for condition=established --timeout=60s crd/servicemonitors.monitoring.coreos.com
-fi
-```
-
-**Expected Result**: ServiceMonitor CRD is available for monitoring integration.
-
-##### 1.3 Clean Previous Deployments
-```bash
-# Remove any existing deployment
-helm uninstall squid 2>/dev/null || true
-
-# Remove namespace
-kubectl delete namespace caching 2>/dev/null || true
-
-# Wait for cleanup
-sleep 10
-```
-
-**Expected Result**: Clean environment with no conflicts.
-
-#### 2. Deployment Tests
-
-##### 2.1 Deploy Squid with Monitoring
-```bash
-# Deploy with monitoring enabled
-helm install squid ./squid \
-  --set squidExporter.enabled=true \
-  --set prometheus.serviceMonitor.enabled=true \
-  --set cert-manager.enabled=false \
-  --wait --timeout=300s
-```
-
-**Expected Result**: Deployment succeeds with `STATUS: deployed`.
-
-##### 2.2 Verify Pod Readiness
-```bash
-# Wait for pods to be ready
-kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=squid -n caching --timeout=120s
-
-# Check pod status
-kubectl get pods -n caching -o wide
-```
-
-**Expected Result**: Pod shows `2/2 Running` (squid + squid-exporter containers).
-
-##### 2.3 Verify Service Creation
-```bash
-# Check service
-kubectl get svc -n caching
-
-# Check service details
-kubectl describe svc squid -n caching
-```
-
-**Expected Result**: Service exposes ports 3128 (proxy) and 9301 (metrics).
-
-##### 2.4 Verify ServiceMonitor (if Prometheus Operator available)
-```bash
-# Check ServiceMonitor
-kubectl get servicemonitor -n caching
-
-# Check ServiceMonitor details
-kubectl describe servicemonitor squid -n caching
-```
-
-**Expected Result**: ServiceMonitor created with correct selector and endpoints.
-
-#### 3. Container Health Tests
-
-##### 3.1 Verify Container Configuration
-```bash
-# Get pod name
-POD_NAME=$(kubectl get pods -n caching -l app.kubernetes.io/name=squid -o jsonpath="{.items[0].metadata.name}")
-echo "Testing pod: $POD_NAME"
-
-# Check container names
-kubectl get pod $POD_NAME -n caching -o jsonpath='{.spec.containers[*].name}'
-```
-
-**Expected Result**: Shows both `squid` and `squid-exporter` containers.
-
-##### 3.2 Check Container Logs
-```bash
-# Check squid container logs
-kubectl logs -n caching $POD_NAME -c squid --tail=10
-
-# Check squid-exporter container logs
-kubectl logs -n caching $POD_NAME -c squid-exporter --tail=10
-```
-
-**Expected Result**:
-- Squid logs show successful startup with no permission errors
-- Squid-exporter logs show successful connection to cache manager
-
-#### 4. Metrics Endpoint Tests
-
-##### 4.1 Test Direct Metrics Access
-```bash
-# Port forward to metrics endpoint
-kubectl port-forward -n caching $POD_NAME 9301:9301 &
-PF_PID=$!
-sleep 3
-
-# Test metrics endpoint
-curl -s http://localhost:9301/metrics | head -20
-
-# Cleanup
-kill $PF_PID 2>/dev/null || true
-```
-
-**Expected Result**: Prometheus metrics displayed starting with `# HELP` and `# TYPE` comments.
-
-##### 4.2 Test Service-Based Metrics Access
-```bash
-# Port forward via service
-kubectl port-forward -n caching svc/squid 9301:9301 &
-PF_PID=$!
-sleep 3
-
-# Test metrics via service
-curl -s http://localhost:9301/metrics | grep -c "^squid_"
-
-# Cleanup
-kill $PF_PID 2>/dev/null || true
-```
-
-**Expected Result**: Number of squid metrics found (typically 20+ metrics).
-
-##### 4.3 Verify Specific Metrics
-```bash
-# Port forward for detailed metrics check
-kubectl port-forward -n caching svc/squid 9301:9301 &
-PF_PID=$!
-sleep 3
-
-# Check for key metrics
-curl -s http://localhost:9301/metrics | grep -E "squid_up|squid_client_http|squid_cache_"
-
-# Cleanup
-kill $PF_PID 2>/dev/null || true
-```
-
-**Expected Result**: Shows key metrics like:
-- `squid_up 1` (service health)
-- `squid_client_http_requests_total` (request counters)
-- `squid_cache_memory_bytes` (cache stats)
-
-#### 5. Cache Manager Tests
-
-##### 5.1 Test Cache Manager Access
-```bash
-# Port forward to proxy port
-kubectl port-forward -n caching $POD_NAME 3128:3128 &
-PF_PID=$!
-sleep 3
-
-# Test cache manager info
-curl -s http://localhost:3128/squid-internal-mgr/info | head -10
-
-# Cleanup
-kill $PF_PID 2>/dev/null || true
-```
-
-**Expected Result**: Cache manager information displayed (version, uptime, etc.).
-
-##### 5.2 Test Cache Manager Counters
-```bash
-# Port forward to proxy port
-kubectl port-forward -n caching $POD_NAME 3128:3128 &
-PF_PID=$!
-sleep 3
-
-# Test cache manager counters
-curl -s http://localhost:3128/squid-internal-mgr/counters | head -10
-
-# Cleanup
-kill $PF_PID 2>/dev/null || true
-```
-
-**Expected Result**: Statistics counters displayed (requests, hits, misses, etc.).
-
-#### 6. Proxy Functionality Tests
-
-##### 6.1 Test Basic Proxy Functionality
-```bash
-# Port forward to proxy port
-kubectl port-forward -n caching $POD_NAME 3128:3128 &
-PF_PID=$!
-sleep 3
-
-# Test proxy with external request
-curl -s --proxy http://localhost:3128 http://httpbin.org/ip
-
-# Cleanup
-kill $PF_PID 2>/dev/null || true
-```
-
-**Expected Result**: JSON response showing IP address, indicating request went through proxy.
-
-##### 6.2 Test Proxy from Within Cluster
-```bash
-# Create test pod and test proxy
-kubectl run test-client --image=curlimages/curl:latest --rm -it -- \
-  curl --proxy http://squid.caching.svc.cluster.local:3128 --connect-timeout 10 http://httpbin.org/ip
-```
-
-**Expected Result**: JSON response showing external IP, confirming proxy works from within cluster.
-
-#### 7. Integration Tests
-
-##### 7.1 Test Metrics Generation After Proxy Usage
-```bash
-# Generate some proxy traffic
-kubectl port-forward -n caching $POD_NAME 3128:3128 &
-PF_PROXY_PID=$!
-sleep 3
-
-# Make a few requests
-curl -s --proxy http://localhost:3128 http://httpbin.org/ip > /dev/null
-curl -s --proxy http://localhost:3128 http://httpbin.org/headers > /dev/null
-
-# Kill proxy port forward
-kill $PF_PROXY_PID 2>/dev/null || true
-sleep 2
-
-# Check if metrics reflect the traffic
-kubectl port-forward -n caching $POD_NAME 9301:9301 &
-PF_METRICS_PID=$!
-sleep 3
-
-# Check request counters
-curl -s http://localhost:9301/metrics | grep "squid_client_http_requests_total"
-
-# Cleanup
-kill $PF_METRICS_PID 2>/dev/null || true
-```
-
-**Expected Result**: Request counters show non-zero values, indicating metrics are being updated.
-
-### Test Summary Checklist
-
-After completing all tests, verify:
-
-- [ ] **Deployment**: Chart installs successfully
-- [ ] **Containers**: Both squid and squid-exporter containers running
-- [ ] **Service**: Ports 3128 and 9301 accessible
-- [ ] **ServiceMonitor**: Created (if Prometheus Operator available)
-- [ ] **Metrics**: squid-exporter provides Prometheus metrics
-- [ ] **Cache Manager**: Accessible via localhost manager interface
-- [ ] **Proxy**: Functions correctly for external requests
-- [ ] **Integration**: Metrics update after proxy usage
-- [ ] **Cleanup**: All resources removed cleanly
-
-### Quick Test Commands
-
-For rapid testing during development:
-
-```bash
-# Quick deployment test
-helm install squid ./squid --set cert-manager.enabled=false --wait
-
-# Quick functionality test
-kubectl port-forward -n caching svc/squid 3128:3128 &
-curl --proxy http://localhost:3128 http://httpbin.org/ip
-pkill -f "kubectl port-forward.*3128"
-
-# Quick metrics test
-kubectl port-forward -n caching svc/squid 9301:9301 &
-curl -s http://localhost:9301/metrics | grep squid_up
-pkill -f "kubectl port-forward.*9301"
-
-# Quick cleanup
-helm uninstall squid && kubectl delete namespace caching
-```
+| Issue | Solution |
+|-------|----------|
+| Cluster exists error | `kind export kubeconfig --name caching` |
+| Image pull errors | `mage build:loadSquid` |
+| Namespace errors | `helm uninstall squid && kubectl delete ns caching` |
+| Connection refused | Check squid ACLs cover your pod CIDR |
+
+For detailed troubleshooting, see [docs/troubleshooting.md](docs/troubleshooting.md).
 
 ## Cleanup
 
-### Automated Cleanup (Recommended)
-
 ```bash
-# Remove everything (cluster, deployments, images) in one command
+# Automated (recommended)
 mage clean
-```
 
-### Manual Cleanup (Advanced)
-
-If you prefer manual control:
-
-#### Remove the Deployment
-
-```bash
-# Uninstall the Helm release
+# Manual
 helm uninstall squid
-
-# Remove the namespaces (optional, will be recreated on next install)
 kubectl delete namespace caching
-
-# If you used the "squid" helm chart to install cert-manager
-kubectl delete namespace cert-manager
-```
-
-#### Remove the kind Cluster
-
-```bash
-# Delete the entire cluster (or use: mage kind:down)
 kind delete cluster --name caching
-```
-
-#### Clean Up Local Images
-
-```bash
-# Remove the local container images
-podman rmi localhost/konflux-ci/squid:latest
-podman rmi localhost/konflux-ci/access-log-exporter:latest
-podman rmi localhost/konflux-ci/squid-test:latest
 ```
 
 ## Chart Structure
 
 ```
 squid/
-├── Chart.yaml              # Chart metadata
-├── values.yaml             # Default configuration values
-├── crds/                   # Custom Resource Definitions
+├── Chart.yaml          # Chart metadata
+├── values.yaml         # Default configuration
+├── crds/               # Custom Resource Definitions
 └── templates/
-    ├── _helpers.tpl         # Template helpers
-    ├── configmap.yaml       # ConfigMap with embedded squid.conf
-    ├── deployment.yaml      # Squid deployment
-    ├── namespace.yaml       # Caching namespace
-    ├── service.yaml         # Squid service
-    ├── serviceaccount.yaml  # Service account
-    ├── servicemonitor.yaml  # Prometheus ServiceMonitor
-    └── NOTES.txt           # Post-install instructions
+    ├── configmap.yaml  # Squid configuration
+    ├── deployment.yaml # StatefulSet deployment
+    ├── service.yaml    # Service definitions
+    └── ...
 ```
 
-## Security Considerations
+## Security
 
-- The proxy runs as non-root user (UID 1001)
-- Access is restricted to RFC 1918 private networks
-- Unsafe ports and protocols are blocked
-- No disk caching is enabled by default (memory-only)
+- Runs as non-root (UID 1001)
+- Restricted to private networks (RFC 1918 + CGNAT 100.64.0.0/10 + link-local)
+- Unsafe ports/protocols blocked
+- Disk-based caching (1 GiB default, backed by PVC)
 
 ## Contributing
 
-When modifying the chart:
+1. Test changes locally with Kind (`mage all`)
+2. Verify the proxy works both within and across namespaces
+3. Check that cleanup procedures work correctly
+4. Update documentation if adding new features
+5. Ensure tests pass before submitting PRs
+6. Follow conventional commits format
 
-1. Test changes locally with kind
-2. Update this README if adding new features
-3. Verify the proxy works both within and across namespaces
-4. Check that cleanup procedures work correctly
+For architecture decisions, see [ADR/](ADR/).
 
-## Automation Benefits
+## Documentation
 
-The Mage-based automation system provides several key benefits:
-
-- **Dependency Management**: Automatically handles prerequisites (cluster → image → deployment)
-- **Error Handling**: Robust error handling with clear feedback
-- **Idempotent Operations**: Can run commands multiple times safely
-- **Smart Logic**: Detects existing resources and handles install vs upgrade scenarios
-- **Consistent Patterns**: All resource types follow the same up/down/status/upClean pattern
-- **Single Command Setup**: `mage all` sets up the complete environment
-- **Efficient Cleanup**: `mage clean` removes all resources in the correct order
-
-For the best experience, use the automation commands instead of manual setup!
+| Document | Description |
+|----------|-------------|
+| [docs/development.md](docs/development.md) | Development setup and prerequisites |
+| [docs/testing.md](docs/testing.md) | Testing guide, VS Code integration, debugging |
+| [docs/monitoring.md](docs/monitoring.md) | Prometheus monitoring configuration |
+| [docs/troubleshooting.md](docs/troubleshooting.md) | Common issues and solutions |
+| [docs/monitoring-tests.md](docs/monitoring-tests.md) | Step-by-step QA testing procedures |
+| [HERMETIC-BUILDS.md](HERMETIC-BUILDS.md) | Hermetic build configuration |
+| [ADR/](ADR/) | Architecture Decision Records |
 
 ## License
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,235 @@
+# Development Setup
+
+This guide covers setting up a local development environment for the caching proxy.
+
+## Prerequisites
+
+### System Requirements
+
+Increase the `inotify` resource limits to avoid Kind issues related to [too many open files](https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files):
+
+```bash
+sudo sysctl fs.inotify.max_user_watches=1048576
+sudo sysctl fs.inotify.max_user_instances=1024
+```
+
+To make permanent, add to `/etc/sysctl.conf`:
+```
+fs.inotify.max_user_watches=1048576
+fs.inotify.max_user_instances=1024
+```
+
+> **Dev Container note**: When using Dev Containers, the automation will fetch these values and verify them against the limits above, failing container initialization if either value is too low.
+
+## Option 1: Manual Installation
+
+### Required Tools
+
+- [Go](https://golang.org/doc/install) 1.25 or later
+- [Podman](https://podman.io/getting-started/installation) (required for Mage automation)
+- [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installation) (Kubernetes in Docker)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/)
+- [Helm](https://helm.sh/docs/intro/install/) v3.x
+- [Mage](https://magefile.org/) - `go install github.com/magefile/mage@v1.16.1`
+- [mirrord](https://mirrord.dev/docs/overview/quick-start/) (optional, for e2e tests)
+- [gcc](https://gcc.gnu.org/) (for CGO)
+
+> **Note**: Mage automation uses Podman explicitly. Docker may work for manual commands but is not tested with automation.
+
+### Debug Symbols (Required for Go Debugging)
+
+```bash
+# Fedora/RHEL
+sudo dnf install -y dnf-plugins-core
+sudo dnf --enablerepo=fedora-debuginfo,updates-debuginfo install -y \
+    glibc-debuginfo \
+    gcc-debuginfo \
+    libgcc-debuginfo
+```
+
+## Option 2: Development Container
+
+The repository includes a dev container with all tools pre-installed.
+
+### Host Requirements
+
+1. **Podman** installed and running
+2. **Docker alias**: The VS Code Dev Containers extension requires the `docker` command:
+   - **Fedora Workstation**: `sudo dnf install podman-docker`
+   - **Fedora Silverblue/Kinoite**: `sudo rpm-ostree install podman-docker`
+   - **Manual**: `sudo ln -s /usr/bin/podman /usr/local/bin/docker`
+
+3. **Podman socket** running:
+   ```bash
+   systemctl --user enable --now podman.socket
+   ```
+
+4. **VS Code** with [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+
+### Usage
+
+1. Open the repo in VS Code
+2. Use "Reopen in Container" command
+3. All tools are pre-configured
+
+## Quick Start
+
+Once prerequisites are met:
+
+```bash
+# Full setup: build, deploy, test (ends with helm test)
+mage all
+
+# Or step by step:
+mage kind:up           # Create cluster
+mage build:squid       # Build image
+mage build:loadSquid   # Load into cluster
+mage squidHelm:up      # Deploy chart
+mage test:cluster      # Run e2e tests
+```
+
+### Verify Your Setup
+
+After deploying, confirm the proxy is working:
+
+```bash
+# From your local machine (port-forward)
+kubectl port-forward -n caching svc/squid 3128:3128
+curl --proxy http://127.0.0.1:3128 http://httpbin.org/ip
+
+# From within the cluster (creates a temporary test pod)
+kubectl run test-curl --image=curlimages/curl:latest --rm -it -- \
+    sh -c 'curl --proxy http://squid.caching.svc.cluster.local:3128 http://httpbin.org/ip'
+
+# Test HTTPS via SSL-bump
+kubectl run test-curl-ssl --image=curlimages/curl:latest --rm -it -- \
+    sh -c 'curl -k --proxy http://squid.caching.svc.cluster.local:3128 https://httpbin.org/ip'
+```
+
+## Mage Command Reference
+
+Run `mage -l` for the full list. Key commands:
+
+| Command | Description |
+|---------|-------------|
+| **Cluster** | |
+| `mage kind:up` | Create/connect to cluster |
+| `mage kind:down` | Remove cluster |
+| `mage kind:status` | Check cluster status |
+| `mage kind:upClean` | Force recreate cluster |
+| **Images** | |
+| `mage build:squid` | Build squid image (squid + squid-exporter + per-site-exporter + store-id + icap-server) |
+| `mage build:loadSquid` | Load squid image into cluster |
+| `mage build:accessLogExporter` | Build access-log-exporter image (for use as sidecar with nginx) |
+| `mage build:loadAccessLogExporter` | Load access-log-exporter into cluster |
+| **Deployment** | |
+| `mage squidHelm:up` | Deploy/upgrade helm chart |
+| `mage squidHelm:down` | Remove deployment |
+| `mage squidHelm:status` | Check deployment status |
+| `mage squidHelm:upClean` | Force redeploy |
+| **Testing** | |
+| `mage test:unit` | Run unit tests (no cluster) |
+| `mage test:cluster` | Run E2E tests with mirrord |
+| `mage test:clusterMultiReplica` | Run E2E tests with multiple replicas |
+| **Cleanup** | |
+| `mage clean` | Remove everything |
+
+### Automation Benefits
+
+- **Dependency management**: Consistent setup without manual version tracking
+- **Idempotency**: Commands like `kind:up` are safe to run multiple times
+- **Consistent patterns**: `up`/`down`/`status`/`upClean` across targets
+- **Single-command setup**: `mage all` handles complete environment
+- **Cleanup ordering**: `mage clean` removes resources in correct order
+
+## Manual Setup Steps
+
+### 1. Create Kind Cluster
+
+```bash
+kind create cluster --name caching
+kubectl cluster-info --context kind-caching
+```
+
+### 2. Build and Load Images
+
+```bash
+# Build squid image (includes squid-exporter, per-site-exporter, store-id, icap-server)
+podman build --target squid -t localhost/konflux-ci/squid:latest -f Containerfile .
+
+# Load into kind
+kind load image-archive --name caching <(podman save localhost/konflux-ci/squid:latest)
+
+# Build access-log-exporter image (minimal image for use as sidecar with nginx monitoring)
+podman build --target access-log-exporter -t localhost/konflux-ci/access-log-exporter:latest -f Containerfile .
+kind load image-archive --name caching <(podman save localhost/konflux-ci/access-log-exporter:latest)
+
+# Build test image
+podman build -t localhost/konflux-ci/squid-test:latest -f test.Containerfile .
+kind load image-archive --name caching <(podman save localhost/konflux-ci/squid-test:latest)
+```
+
+### 3. Deploy with Helm
+
+```bash
+# Deploy for local dev — enables nginx reverse proxy (required for access-log-exporter sidecar)
+helm install squid ./squid --set environment=dev --set nginx.enabled=true
+kubectl get pods -n caching
+```
+
+### Helm Configuration Examples
+
+```bash
+# Full install with cert-manager
+helm install squid ./squid
+
+# Without deploying cert-manager (requires cert-manager already installed on the cluster)
+# Note: Certificate resources are still created — cert-manager must be present
+helm install squid ./squid --set installCertManagerComponents=false
+
+# Install cert-manager + trust-manager without creating certificate resources
+helm install squid ./squid --set selfsigned-issuer.enabled=false
+
+# Disable TLS certificate resources (cert-manager still deployed)
+helm install squid ./squid --set installCertManagerComponents=false --set selfsigned-bundle.enabled=false
+
+# Local development
+helm install squid ./squid --set environment=dev --set nginx.enabled=true
+```
+
+## Cleanup
+
+```bash
+mage clean              # Remove cluster + images (recommended)
+```
+
+### Manual Cleanup
+
+```bash
+# Remove Helm release and namespace
+helm uninstall squid
+kubectl delete namespace caching
+
+# Remove cert-manager namespace (if installed via chart)
+kubectl delete namespace cert-manager
+
+# Delete Kind cluster
+kind delete cluster --name caching
+
+# Remove local images (optional)
+podman rmi localhost/konflux-ci/squid:latest
+podman rmi localhost/konflux-ci/access-log-exporter:latest
+podman rmi localhost/konflux-ci/squid-test:latest
+```
+
+> **Note**: `mage clean` handles most cleanup automatically. Manual image removal is only needed if you want to reclaim disk space.
+
+## Hermetic Builds
+
+This project uses hermetic (network-isolated) builds in Konflux CI to ensure reproducible, supply-chain-secure container images. Dependencies are pre-fetched and version-locked before builds run with network access disabled.
+
+See [HERMETIC-BUILDS.md](../HERMETIC-BUILDS.md) for guidance on updating dependency lock files.
+
+## Troubleshooting
+
+See [troubleshooting.md](troubleshooting.md) for common issues and solutions.

--- a/docs/monitoring-tests.md
+++ b/docs/monitoring-tests.md
@@ -1,0 +1,311 @@
+# Monitoring Integration Tests
+
+This document provides step-by-step testing instructions for validating the Squid proxy monitoring integration.
+
+## Complete Monitoring Integration Tests
+
+### 1. Pre-Test Setup
+
+#### 1.1 Verify Cluster Connectivity
+```bash
+# Test basic cluster access
+kubectl cluster-info
+
+# Show current context
+kubectl config current-context
+
+# Verify nodes are ready
+kubectl get nodes
+```
+
+**Expected Result**: Cluster information displays correctly with no errors.
+
+#### 1.2 Install Prometheus Operator (if needed)
+
+> **Note**: We pin to a specific release (v0.90.1) rather than `main` to ensure reproducibility 
+> and avoid applying unreviewed changes from upstream.
+
+```bash
+# Check if ServiceMonitor CRD exists
+kubectl get crd servicemonitors.monitoring.coreos.com
+
+# If the CRD doesn't exist, install Prometheus Operator (pinned to v0.90.1)
+if ! kubectl get crd servicemonitors.monitoring.coreos.com &> /dev/null; then
+  echo "Installing Prometheus Operator..."
+  kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.90.1/bundle.yaml
+
+  # Wait for CRDs to be established
+  kubectl wait --for condition=established --timeout=60s crd/servicemonitors.monitoring.coreos.com
+fi
+```
+
+**Expected Result**: ServiceMonitor CRD is available for monitoring integration.
+
+#### 1.3 Clean Previous Deployments
+```bash
+# Remove any existing deployment
+helm uninstall squid 2>/dev/null || true
+
+# Remove namespace
+kubectl delete namespace caching 2>/dev/null || true
+
+# Wait for cleanup
+sleep 10
+```
+
+**Expected Result**: Clean environment with no conflicts.
+
+### 2. Deployment Tests
+
+#### 2.1 Deploy Squid with Monitoring
+```bash
+# Deploy with monitoring enabled
+helm install squid ./squid \
+  --set squidExporter.enabled=true \
+  --set prometheus.serviceMonitor.enabled=true \
+  --set cert-manager.enabled=false \
+  --wait --timeout=300s
+```
+
+**Expected Result**: Deployment succeeds with `STATUS: deployed`.
+
+#### 2.2 Verify Pod Readiness
+```bash
+# Wait for pods to be ready
+kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=squid -n caching --timeout=120s
+
+# Check pod status
+kubectl get pods -n caching -o wide
+```
+
+**Expected Result**: Pod shows `2/2 Running` (squid + squid-exporter containers).
+
+#### 2.3 Verify Service Creation
+```bash
+# Check service
+kubectl get svc -n caching
+
+# Check service details
+kubectl describe svc squid -n caching
+```
+
+**Expected Result**: Service exposes ports 3128 (proxy) and 9301 (metrics).
+
+#### 2.4 Verify ServiceMonitor (if Prometheus Operator available)
+```bash
+# Check ServiceMonitor
+kubectl get servicemonitor -n caching
+
+# Check ServiceMonitor details
+kubectl describe servicemonitor squid -n caching
+```
+
+**Expected Result**: ServiceMonitor created with correct selector and endpoints.
+
+### 3. Container Health Tests
+
+#### 3.1 Verify Container Configuration
+```bash
+# Get pod name
+POD_NAME=$(kubectl get pods -n caching -l app.kubernetes.io/name=squid -o jsonpath="{.items[0].metadata.name}")
+echo "Testing pod: $POD_NAME"
+
+# Check container names
+kubectl get pod $POD_NAME -n caching -o jsonpath='{.spec.containers[*].name}'
+```
+
+**Expected Result**: Shows both `squid` and `squid-exporter` containers.
+
+#### 3.2 Check Container Logs
+```bash
+# Check squid container logs
+kubectl logs -n caching $POD_NAME -c squid --tail=10
+
+# Check squid-exporter container logs
+kubectl logs -n caching $POD_NAME -c squid-exporter --tail=10
+```
+
+**Expected Result**:
+- Squid logs show successful startup with no permission errors
+- Squid-exporter logs show successful connection to cache manager
+
+### 4. Metrics Endpoint Tests
+
+#### 4.1 Test Direct Metrics Access
+```bash
+# Port forward to metrics endpoint
+kubectl port-forward -n caching $POD_NAME 9301:9301 &
+PF_PID=$!
+sleep 3
+
+# Test metrics endpoint
+curl -s http://localhost:9301/metrics | head -20
+
+# Cleanup
+kill $PF_PID 2>/dev/null || true
+```
+
+**Expected Result**: Prometheus metrics displayed starting with `# HELP` and `# TYPE` comments.
+
+#### 4.2 Test Service-Based Metrics Access
+```bash
+# Port forward via service
+kubectl port-forward -n caching svc/squid 9301:9301 &
+PF_PID=$!
+sleep 3
+
+# Test metrics via service
+curl -s http://localhost:9301/metrics | grep -c "^squid_"
+
+# Cleanup
+kill $PF_PID 2>/dev/null || true
+```
+
+**Expected Result**: Number of squid metrics found (typically 20+ metrics).
+
+#### 4.3 Verify Specific Metrics
+```bash
+# Port forward for detailed metrics check
+kubectl port-forward -n caching svc/squid 9301:9301 &
+PF_PID=$!
+sleep 3
+
+# Check for key metrics
+curl -s http://localhost:9301/metrics | grep -E "squid_up|squid_client_http|squid_cache_"
+
+# Cleanup
+kill $PF_PID 2>/dev/null || true
+```
+
+**Expected Result**: Shows key metrics like:
+- `squid_up 1` (service health)
+- `squid_client_http_requests_total` (request counters)
+- `squid_cache_memory_bytes` (cache stats)
+
+### 5. Cache Manager Tests
+
+#### 5.1 Test Cache Manager Access
+```bash
+# Port forward to proxy port
+kubectl port-forward -n caching $POD_NAME 3128:3128 &
+PF_PID=$!
+sleep 3
+
+# Test cache manager info
+curl -s http://localhost:3128/squid-internal-mgr/info | head -10
+
+# Cleanup
+kill $PF_PID 2>/dev/null || true
+```
+
+**Expected Result**: Cache manager information displayed (version, uptime, etc.).
+
+#### 5.2 Test Cache Manager Counters
+```bash
+# Port forward to proxy port
+kubectl port-forward -n caching $POD_NAME 3128:3128 &
+PF_PID=$!
+sleep 3
+
+# Test cache manager counters
+curl -s http://localhost:3128/squid-internal-mgr/counters | head -10
+
+# Cleanup
+kill $PF_PID 2>/dev/null || true
+```
+
+**Expected Result**: Statistics counters displayed (requests, hits, misses, etc.).
+
+### 6. Proxy Functionality Tests
+
+#### 6.1 Test Basic Proxy Functionality
+```bash
+# Port forward to proxy port
+kubectl port-forward -n caching $POD_NAME 3128:3128 &
+PF_PID=$!
+sleep 3
+
+# Test proxy with external request
+curl -s --proxy http://localhost:3128 http://httpbin.org/ip
+
+# Cleanup
+kill $PF_PID 2>/dev/null || true
+```
+
+**Expected Result**: JSON response showing IP address, indicating request went through proxy.
+
+#### 6.2 Test Proxy from Within Cluster
+```bash
+# Create test pod and test proxy
+kubectl run test-client --image=curlimages/curl:latest --rm -it -- \
+  curl --proxy http://squid.caching.svc.cluster.local:3128 --connect-timeout 10 http://httpbin.org/ip
+```
+
+**Expected Result**: JSON response showing external IP, confirming proxy works from within cluster.
+
+### 7. Integration Tests
+
+#### 7.1 Test Metrics Generation After Proxy Usage
+```bash
+# Generate some proxy traffic
+kubectl port-forward -n caching $POD_NAME 3128:3128 &
+PF_PROXY_PID=$!
+sleep 3
+
+# Make a few requests
+curl -s --proxy http://localhost:3128 http://httpbin.org/ip > /dev/null
+curl -s --proxy http://localhost:3128 http://httpbin.org/headers > /dev/null
+
+# Kill proxy port forward
+kill $PF_PROXY_PID 2>/dev/null || true
+sleep 2
+
+# Check if metrics reflect the traffic
+kubectl port-forward -n caching $POD_NAME 9301:9301 &
+PF_METRICS_PID=$!
+sleep 3
+
+# Check request counters
+curl -s http://localhost:9301/metrics | grep "squid_client_http_requests_total"
+
+# Cleanup
+kill $PF_METRICS_PID 2>/dev/null || true
+```
+
+**Expected Result**: Request counters show non-zero values, indicating metrics are being updated.
+
+## Test Summary Checklist
+
+After completing all tests, verify:
+
+- [ ] **Deployment**: Chart installs successfully
+- [ ] **Containers**: Both squid and squid-exporter containers running
+- [ ] **Service**: Ports 3128 and 9301 accessible
+- [ ] **ServiceMonitor**: Created (if Prometheus Operator available)
+- [ ] **Metrics**: squid-exporter provides Prometheus metrics
+- [ ] **Cache Manager**: Accessible via localhost manager interface
+- [ ] **Proxy**: Functions correctly for external requests
+- [ ] **Integration**: Metrics update after proxy usage
+- [ ] **Cleanup**: All resources removed cleanly
+
+## Quick Test Commands
+
+For rapid testing during development:
+
+```bash
+# Quick deployment test
+helm install squid ./squid --set cert-manager.enabled=false --wait
+
+# Quick functionality test
+kubectl port-forward -n caching svc/squid 3128:3128 &
+curl --proxy http://localhost:3128 http://httpbin.org/ip
+pkill -f "kubectl port-forward.*3128"
+
+# Quick metrics test
+kubectl port-forward -n caching svc/squid 9301:9301 &
+curl -s http://localhost:9301/metrics | grep squid_up
+pkill -f "kubectl port-forward.*9301"
+
+# Quick cleanup
+helm uninstall squid && kubectl delete namespace caching
+```

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,150 @@
+# Prometheus Monitoring
+
+This chart includes comprehensive Prometheus monitoring capabilities through:
+
+- Integrated upstream [squid-exporter](https://github.com/boynux/squid-exporter) for standard Squid metrics
+- A per-site exporter that parses Squid access logs (via STDOUT piping) to emit per-host request metrics
+
+Both exporters are bundled into the single Squid container image.
+
+## Metrics Overview
+
+The monitoring system provides detailed metrics about Squid's operational status:
+
+- **Liveness**: Squid service information and connection status
+- **Bandwidth Usage**: Client HTTP and Server HTTP traffic metrics
+- **Hit/Miss Rates**: Cache performance metrics (general and detailed)
+- **Storage Utilization**: Cache information and memory usage
+- **Service Times**: Response times for different operations
+- **Connection Information**: Active connections and request details
+
+## Enabling Monitoring
+
+Monitoring is enabled by default. To customize or disable it:
+
+```yaml
+# In values.yaml or via --set flags
+squidExporter:
+  enabled: true  # Set to false to disable
+  port: 9301
+  metricsPath: "/metrics"
+  extractServiceTimes: "true"  # Enables detailed service time metrics
+  resources:
+    requests:
+      cpu: 10m
+      memory: 16Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi
+```
+
+Per-site exporter (enabled by default):
+
+```yaml
+# In values.yaml or via --set flags
+perSiteExporter:
+  enabled: true
+  port: 9302
+  metricsPath: "/metrics"
+```
+
+## Prometheus Integration
+
+### Option 1: Prometheus Operator (Recommended)
+
+If you're using Prometheus Operator, the chart automatically creates a ServiceMonitor:
+
+```yaml
+prometheus:
+  serviceMonitor:
+    enabled: true
+    interval: 30s
+    scrapeTimeout: 10s
+    namespace: ""  # Leave empty to use the same namespace as the app
+```
+
+When enabled, the ServiceMonitor exposes endpoints for both exporters: `9301` (standard, HTTP) and `9302` (per-site, **HTTPS**). The per-site endpoint is scraped with `scheme: https` by default, with TLS configured via `prometheus.serviceMonitor.perSiteTLS` (defaults to the `caching-tls` secret).
+
+### Option 2: Manual Prometheus Configuration
+
+**ServiceMonitor CRD Included:**
+
+The chart includes the ServiceMonitor CRD in the `crds/` directory, so it will be automatically installed by Helm when the chart is deployed.
+
+If you don't want ServiceMonitor functionality, you can disable it:
+```bash
+helm install squid ./squid --set prometheus.serviceMonitor.enabled=false
+```
+
+**For non-Prometheus Operator setups**, disable ServiceMonitor and use manual Prometheus configuration:
+
+```yaml
+scrape_configs:
+  - job_name: 'squid-proxy'
+    static_configs:
+      - targets: ['squid.caching.svc.cluster.local:9301']
+    scrape_interval: 30s
+    metrics_path: '/metrics'
+```
+
+**Complete example**: See `docs/prometheus-config-example.yaml` in this repository for a full Prometheus configuration file.
+
+## Available Metrics
+
+### Standard Squid Metrics (Port 9301)
+
+- `squid_client_http_requests_total`: Total client HTTP requests
+- `squid_client_http_hits_total`: Total client HTTP hits
+- `squid_client_http_errors_total`: Total client HTTP errors
+- `squid_server_http_requests_total`: Total server HTTP requests
+- `squid_cache_memory_bytes`: Cache memory usage
+- `squid_cache_disk_bytes`: Cache disk usage
+- `squid_service_times_seconds`: Service times for different operations
+- `squid_up`: Squid availability status
+
+### Per-site Metrics (Port 9302)
+
+- `squid_site_requests_total{hostname="<hostname>"}`: Total requests per origin host
+- `squid_site_hits_total{hostname="<hostname>"}`: Cache hits per host
+- `squid_site_misses_total{hostname="<hostname>"}`: Cache misses per host
+- `squid_site_bytes_total{hostname="<hostname>"}`: Bytes transferred per host
+- `squid_site_hit_ratio{hostname="<hostname>"}`: Hit ratio gauge per host
+- `squid_site_response_time_seconds{hostname="<hostname>",le="..."}`: Response time histogram per host
+
+## Accessing Metrics
+
+### Via Port Forward
+
+```bash
+# Forward the standard squid-exporter metrics port
+kubectl port-forward -n caching svc/squid 9301:9301
+
+# View standard metrics in your browser or with curl
+curl http://localhost:9301/metrics
+```
+
+Per-site exporter metrics (note: port 9302 uses **HTTPS**):
+
+```bash
+# Forward the per-site exporter metrics port
+kubectl port-forward -n caching svc/squid 9302:9302
+
+# View per-site metrics (TLS, skip cert verification for local testing)
+curl -k https://localhost:9302/metrics
+```
+
+### Via Service
+
+The metrics are exposed on the service:
+
+```bash
+# Standard squid-exporter metrics (from within the cluster)
+curl http://squid.caching.svc.cluster.local:9301/metrics
+
+# Per-site exporter metrics (from within the cluster — uses HTTPS)
+curl -k https://squid.caching.svc.cluster.local:9302/metrics
+```
+
+## Troubleshooting Metrics
+
+See the [troubleshooting guide](troubleshooting.md#metrics-troubleshooting) for common monitoring issues.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,105 @@
+# Testing Guide
+
+This guide covers running and debugging tests for the caching proxy.
+
+## Quick Start
+
+```bash
+# Full test suite via Helm (recommended)
+mage all
+
+# E2E tests with local debugging (mirrord)
+mage test:cluster
+```
+
+> **Note**: `mage all` sets up the complete environment (cluster, images, deployment) and ends by invoking `helm test squid --timeout=15m`. It runs **unit tests** and **Helm-driven tests** — it does not run `mage test:cluster` (mirrord E2E).
+
+## Running Tests via Helm
+
+When running `helm test` directly (not through `mage all`), you must specify a timeout of at least 420 seconds:
+
+```bash
+helm test squid --timeout=420s
+```
+
+The default Helm test timeout is 5 minutes (300 seconds), which may not be sufficient for all tests to complete.
+
+## Running Tests with Mirrord
+
+For local development and debugging, use mirrord to run tests with cluster network access:
+
+```bash
+# Setup test environment first
+mage squidHelm:up
+
+# Run tests with cluster network access
+mage test:cluster
+
+# Run with multiple replicas
+mage test:clusterMultiReplica
+```
+
+This uses mirrord to "steal" network connections from a target pod and runs the test locally (outside of the Kind cluster) with Ginkgo. This allows for local debugging without rebuilding test containers.
+
+## Filtering Tests
+
+Use the `GINKGO_LABEL_FILTER` environment variable to control which tests run:
+
+```bash
+# Skip tests with external dependencies (via Helm)
+GINKGO_LABEL_FILTER='!external-deps' mage all
+
+# Skip tests with external dependencies (via mirrord)
+GINKGO_LABEL_FILTER='!external-deps' mage test:cluster
+```
+
+For syntax details, see the [Ginkgo label-filter documentation](https://onsi.github.io/ginkgo/#spec-labels).
+
+## VS Code Integration
+
+The repository includes complete VS Code configuration for Ginkgo testing.
+
+### Debug Configurations
+
+Use VS Code's debug panel (F5) to run tests with breakpoints:
+
+| Configuration | Description |
+|---------------|-------------|
+| Debug Ginkgo E2E Tests | Run all E2E tests with debugging |
+| Debug Ginkgo Tests (Current File) | Debug tests in the currently open file |
+| Run Ginkgo Tests with Coverage | Generate test coverage reports |
+
+### VS Code Tasks
+
+Available via Ctrl+Shift+P → "Tasks: Run Task":
+
+| Task | Description |
+|------|-------------|
+| Setup Test Environment | Runs `mage all` to prepare everything |
+| Run Ginkgo E2E Tests | Run E2E tests locally with Ginkgo + mirrord |
+| Run Ginkgo Tests (Current Directory) | Run tests in the currently open directory |
+| Run Ginkgo Tests with Coverage | Generate test coverage reports |
+| Run Focused Ginkgo Tests | Run specific test patterns |
+| Check Test Environment Status | Run `mage kind:status && mage squidHelm:status` |
+| Generate Ginkgo Test File | Bootstrap a new Ginkgo test file |
+| Clean Test Environment | Clean up all resources |
+
+## Contributing to Tests
+
+When adding new tests:
+
+1. **Use test helpers**: Leverage `tests/testhelpers/` for common operations
+2. **Follow Ginkgo patterns**: Use `Describe`, `Context`, `It` for clear test structure
+3. **Add cache-busting**: Use unique URLs to prevent test interference
+4. **Verify cleanup**: Ensure tests clean up resources properly
+5. **Update VS Code config**: Add debug configurations for new test files
+
+## Mage Test Commands
+
+| Command | Description |
+|---------|-------------|
+| `mage test:unit` | Run unit tests (no cluster required) |
+| `mage test:cluster` | Run E2E tests with mirrord |
+| `mage test:clusterMultiReplica` | Run E2E tests with multiple replicas |
+
+For all available commands, run `mage -l`.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,233 @@
+# Troubleshooting
+
+This guide covers common issues and their solutions when working with the caching proxy.
+
+## Common Issues
+
+### 1. Cluster Already Exists Error
+
+**Symptom**: When trying to create a kind cluster:
+```
+ERROR: failed to create cluster: node(s) already exist for a cluster with the name "kind"
+```
+
+**Solution**: Either use the existing cluster or delete it first:
+```bash
+# Option 1: Use existing cluster (recommended for dev container users)
+kind export kubeconfig --name caching
+kubectl cluster-info --context kind-caching
+
+# Option 2: Delete and recreate
+kind delete cluster --name caching
+kind create cluster --name caching
+```
+
+### 2. kubectl Access Issues (Dev Container)
+
+**Symptom**: `kubectl` commands fail with connection errors when using the dev container
+
+**Solution**: Configure kubectl access to the existing cluster:
+```bash
+# Check current context
+kubectl config current-context
+
+# List available contexts
+kubectl config get-contexts
+
+# Export kubeconfig for existing cluster
+kind export kubeconfig --name caching
+
+# Switch to the kind context if needed
+kubectl config use-context kind-caching
+
+# Test connectivity
+kubectl get pods --all-namespaces
+```
+
+### 3. Image Pull Errors
+
+**Symptom**: Pod shows `ImagePullBackOff` or `ErrImagePull`
+
+**Solution**: Ensure the image is loaded into kind:
+```bash
+# Simplest fix: use mage to rebuild and reload
+mage build:loadSquid
+
+# Or manually check and reload:
+docker exec -it caching-control-plane crictl images | grep squid
+kind load image-archive --name caching <(podman save localhost/konflux-ci/squid:latest)
+```
+
+### 4. Permission Denied Errors
+
+**Symptom**: Pod logs show `Permission denied` when accessing `/etc/squid/squid.conf`
+
+**Solution**: This is usually resolved by the correct security context in our chart. Verify:
+```bash
+kubectl describe pod -n caching $(kubectl get pods -n caching -o name | head -1)
+```
+
+Look for:
+- `runAsUser: 1001`
+- `runAsGroup: 0`
+- `fsGroup: 0`
+
+### 5. Namespace Already Exists Errors
+
+**Symptom**: Helm install fails with namespace ownership errors
+
+**Solution**: Clean up and reinstall:
+```bash
+helm uninstall squid 2>/dev/null || true
+kubectl delete namespace caching 2>/dev/null || true
+# Wait a few seconds for cleanup
+sleep 5
+helm install squid ./squid
+```
+
+### 6. Connection Refused from Pods
+
+**Symptom**: Pods cannot connect to the proxy
+
+**Solution**: Check if the pod network CIDR is covered by Squid's ACLs:
+```bash
+# Check cluster CIDR
+kubectl cluster-info dump | grep -i cidr
+
+# Verify it's covered by the localnet ACLs in squid.conf
+# Default ACLs cover: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 (RFC 1918),
+#   100.64.0.0/10 (CGNAT), 169.254.0.0/16 (link-local), and IPv6 equivalents
+```
+
+### 7. Test Pod IP Not Available
+
+**Symptom**: Tests fail with "POD_IP environment variable not set"
+
+**Solution**: Ensure downward API is configured (automatically handled by Helm chart):
+```bash
+kubectl describe pod -n caching <test-pod-name>
+```
+
+### 8. Mirrord Connection Issues
+
+**Symptom**: `mage test:cluster` fails with mirrord connection errors
+
+**Solution**: Verify mirrord infrastructure is deployed and working:
+```bash
+# Verify mirrord target pod is ready
+kubectl get pods -n caching -l app.kubernetes.io/component=mirrord-target
+
+# Check mirrord target pod logs
+kubectl logs -n caching mirrord-test-target
+
+# Verify mirrord configuration
+cat .mirrord/mirrord.json
+
+# Ensure mirrord is installed
+which mirrord
+```
+
+### 9. Test Failures
+
+**Symptom**: Tests fail unexpectedly or show connection issues
+
+**Solution**: Debug test execution and cluster state:
+```bash
+# Run tests with verbose output
+mage test:cluster  # Check output for detailed error messages
+
+# Verify cluster state before running tests
+mage squidHelm:status
+
+# Check if all pods are running
+kubectl get pods -n caching
+
+# Verify proxy connectivity manually
+kubectl run debug --image=curlimages/curl:latest --rm -it -- \
+  curl -v --proxy http://squid.caching.svc.cluster.local:3128 http://httpbin.org/ip
+
+# View test logs from helm tests
+kubectl logs -n caching -l app.kubernetes.io/component=test
+```
+
+### 10. Working with Existing kind Clusters (Dev Container Users)
+
+**Symptom**: You're using the dev container and have an existing kind cluster with a different name
+
+**Solution**: Either use the existing cluster or create the expected one:
+```bash
+# Option 1: Check what clusters exist
+kind get clusters
+
+# Option 2: Export kubeconfig for existing cluster (if using default 'kind' cluster)
+kind export kubeconfig --name kind
+kubectl config use-context kind-kind
+
+# Option 3: Create the expected 'caching' cluster for consistency with automation
+kind create cluster --name caching
+```
+
+## Debugging Commands
+
+```bash
+# Check pod status
+kubectl get pods -n caching
+
+# View pod logs (Squid runs as a StatefulSet)
+kubectl logs -n caching statefulset/squid
+
+# Test connectivity from within cluster
+kubectl run debug --image=curlimages/curl:latest --rm -it -- curl -v --proxy http://squid.caching.svc.cluster.local:3128 http://httpbin.org/ip
+
+# Check service endpoints
+kubectl get endpoints -n caching
+
+# Verify test infrastructure (when running tests)
+kubectl get pods -n caching -l app.kubernetes.io/component=mirrord-target
+kubectl get pods -n caching -l app.kubernetes.io/component=test
+
+# View test logs from helm tests
+kubectl logs -n caching -l app.kubernetes.io/component=test
+```
+
+## Health Checks
+
+The deployment includes TCP-based liveness and readiness probes on port 3128. You may see health check entries in the access logs as:
+
+```
+error:transaction-end-before-headers
+```
+
+This is normal - Kubernetes is performing TCP health checks without sending complete HTTP requests.
+
+## Metrics Troubleshooting
+
+### No Metrics Appearing
+
+1. **Check if the squid container is running**:
+   ```bash
+   kubectl get pods -n caching
+   kubectl logs -n caching statefulset/squid -c squid-exporter
+   ```
+
+2. **Verify cache manager access**:
+   ```bash
+   # Test from within the pod
+   kubectl exec -n caching statefulset/squid -c squid-exporter -- \
+     curl -s http://localhost:3128/squid-internal-mgr/info
+   ```
+
+3. **Check ServiceMonitor (if using Prometheus Operator)**:
+   ```bash
+   kubectl get servicemonitor -n caching
+   kubectl describe servicemonitor -n caching squid
+   ```
+
+### Metrics Access Denied
+
+If you see "access denied" errors, ensure that the squid configuration allows localhost manager access. The default configuration should work, but if you've modified the configuration in `squid/templates/configmap.yaml`, make sure these lines are present:
+
+```
+http_access allow localhost manager
+http_access deny manager
+```


### PR DESCRIPTION
Slim down README from 1110 to ~210 lines, moving detailed content to docs/ directory for better organization:
- docs/development.md: prerequisites, dev container setup
- docs/monitoring.md: Prometheus configuration details
- docs/troubleshooting.md: common issues and solutions
- docs/monitoring-tests.md: step-by-step QA procedures


Assisted-by:: Cursor

### Author's Checklist
- [ ] I understand the problem that the PR is trying to address.
- [ ] I understand the solution and its role and impact within the wider system.
- [ ] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
