### PR TITLE
fix(tekton): update rpms-signature-scan task to trusted version

### DIFF
--- a/.tekton/access-log-exporter-pull-request.yaml
+++ b/.tekton/access-log-exporter-pull-request.yaml
@@ -586,7 +586,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:47b81d6b3d752649eddfbb8b3fd8f6522c4bb07f6d1946f9bc45dae3f92e2c9a
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:ce4bace2998b02d8a4da188df4f460e1952770ccd1d2fadddefd4f2ba748705b
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/access-log-exporter-push.yaml
+++ b/.tekton/access-log-exporter-push.yaml
@@ -585,7 +585,7 @@ spec:
         - name: name
           value: rpms-signature-scan
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:47b81d6b3d752649eddfbb8b3fd8f6522c4bb07f6d1946f9bc45dae3f92e2c9a
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:ce4bace2998b02d8a4da188df4f460e1952770ccd1d2fadddefd4f2ba748705b
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
Update access-log-exporter pipelines to use the latest trusted version of rpms-signature-scan task, resolving Enterprise Contract violations.
Assisted by: Cursor

### Author's Checklist
- [ ] I understand the problem that the PR is trying to address.
- [ ] I understand the solution and its role and impact within the wider system.
- [ ] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
