### PR TITLE
chore(KFLUXVNGD-836): disable major updates for indirect Go dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -51,6 +51,13 @@
   ],
   "packageRules": [
     {
+      "description": "Disable major version updates for indirect Go dependencies since they are resolved by go mod tidy based on direct dependency requirements",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
       "description": "Group all cert-manager components",
       "groupName": "cert-manager",
       "automerge": true,


### PR DESCRIPTION
Indirect Go dependencies are resolved by go mod tidy based on direct dependency requirements. Major version update PRs for these are misleading since the actual version is determined by the direct dependency constraints, not by what Renovate proposes.

Assisted-by: Claude claude-opus-4-6

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [ ] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
