### PR TITLE
chore(deps): auto-merge non-major Go module updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -104,6 +104,14 @@
       ]
     },
     {
+      "description": "Auto-merge non-major Go module updates",
+      "matchManagers": ["gomod"],
+      "excludeDatasources": ["golang-version"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "automerge": true,
+      "autoApprove": true
+    },
+    {
       "description": "Auto-merge Go toolchain patch updates (go.mod and Containerfile)",
       "groupName": "go-toolchain",
       "matchDatasources": [


### PR DESCRIPTION
Reduce toil from manually reviewing and merging minor, patch, and digest Go dependency bumps. Major updates still require manual review to catch breaking changes.

Assisted-by: Claude claude-opus-4-6

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [ ] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
