### PR TITLE
fix(tekton): fix build-instrumented-image task in push pipeline

### DIFF
--- a/.tekton/squid-push.yaml
+++ b/.tekton/squid-push.yaml
@@ -266,10 +266,18 @@ spec:
         - ENABLE_COVERAGE=true
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
+      - name: PRIVILEGED_NESTED
+        value: $(params.privileged-nested)
       - name: SOURCE_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
       - name: CACHI2_ARTIFACT
         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: BUILDAH_FORMAT
+        value: $(params.buildah-format)
+      - name: HTTP_PROXY
+        value: $(tasks.init.results.http-proxy)
+      - name: NO_PROXY
+        value: $(tasks.init.results.no-proxy)
       runAfter:
       - prefetch-dependencies
       taskRef:
@@ -281,11 +289,6 @@ spec:
         - name: kind
           value: task
         resolver: bundles
-      when:
-      - input: $(tasks.init.results.build)
-        operator: in
-        values:
-        - "true"
     - name: build-image-index
       params:
       - name: IMAGE


### PR DESCRIPTION
The automated Konflux references update (522f755) bumped the init task from 0.2 to 0.4, which removed the "build" result. The build-instrumented-image task still referenced that result in a when condition, causing the pipeline to fail validation with: "build" is not a named result returned by pipeline task "init".

Remove the stale when condition and add missing params (BUILDAH_FORMAT, HTTP_PROXY, NO_PROXY) to match build-container.

Assisted-by: Claude claude-opus-4-6

### Author's Checklist
- [ ] I understand the problem that the PR is trying to address.
- [ ] I understand the solution and its role and impact within the wider system.
- [ ] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
