### PR TITLE
fix(KFLUXVNGD-990): remove free-disk-space step

### DIFF
--- a/.github/workflows/devcontainer-ci.yml
+++ b/.github/workflows/devcontainer-ci.yml
@@ -16,18 +16,6 @@ jobs:
       id-token: write
 
     steps:
-    - name: Free disk space
-      uses: BRAINSia/free-disk-space@v2
-      with:
-        tool-cache: false
-        mandb:   true
-        android: true
-        dotnet: true
-        haskell: true
-        large-packages: true
-        docker-images: true
-        swap-storage: true
-
     - name: Checkout repository
       uses: actions/checkout@v4
 


### PR DESCRIPTION
GitHub runners now provide enough disk space, so the cleanup step is no longer needed. Removing it also fixes CI breakage caused by free-disk-space leaving google-cloud-cli in a broken dpkg state on newer runner images.


Assisted-by: Claude Opus 4.6 (via Claude Code)

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [x] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
