### PR TITLE
feat: add nginx redirect interception and redirect target caching

### DIFF
--- a/squid/templates/nginx-configmap.yaml
+++ b/squid/templates/nginx-configmap.yaml
@@ -130,9 +130,12 @@ data:
             }
 
             {{- range .Values.nginx.cache.allowList }}
-            # Cached location matching pattern: {{ . }}
+            # AllowList location matching pattern: {{ . }}
             location ~ {{ . }} {
-                # Forward requests to the upstream server
+                # Forward requests to the upstream server.
+                # No caching at this level — the upstream is always contacted so it
+                # can enforce authorization (e.g. return 403 for banned content).
+                # Only redirect targets are cached, via @handle_redirect.
                 proxy_pass $upstream_url;
 
                 # Send the upstream hostname so the backend receives the correct Host header
@@ -146,18 +149,42 @@ data:
                 proxy_set_header Authorization "__AUTH_HEADER__";
                 {{- end }}
 
+                # Intercept redirect responses and follow them via @handle_redirect.
+                # Only status codes listed in error_page are intercepted; 403s, 404s, etc.
+                # pass through from the upstream as-is.
+                proxy_intercept_errors on;
+                error_page 301 302 307 308 = @handle_redirect;
+            }
+            {{- end }}
+
+            {{- if .Values.nginx.cache.allowList }}
+            # Named location for following redirects from the upstream.
+            # Fetches the redirect target and caches the response keyed on the
+            # original request URI (not the redirect target URL).
+            location @handle_redirect {
+                # Capture the redirect target URL from the upstream's Location header
+                set $redirect_url $upstream_http_location;
+                proxy_pass $redirect_url;
+
+                # Enable SNI for HTTPS redirect targets (e.g. S3 presigned URLs)
+                proxy_ssl_server_name on;
+
                 # Use the disk cache defined in proxy_cache_path
                 proxy_cache backend_cache;
 
-                # Cache successful responses (200 OK) for 1 day
-                proxy_cache_valid 200 1d;
+                # Cache keyed on the original request URI, not the redirect target URL,
+                # so repeated requests for the same artifact hit the cache
+                proxy_cache_key "$scheme$host$request_uri";
 
-                # Serve stale cached content when the upstream server is unavailable or slow,
+                # Cache successful responses (200 OK) for the configured TTL
+                proxy_cache_valid 200 {{ .Values.nginx.cache.ttl }};
+
+                # Serve stale cached content when the redirect target is unavailable or slow,
                 # improving resilience during upstream outages
                 proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
 
                 # Prevent multiple simultaneous requests for the same uncached
-                # artifact from all hitting the upstream server; only one fetches, others wait
+                # artifact from all hitting the redirect target; only one fetches, others wait
                 proxy_cache_lock on;
 
                 # Add header showing cache status (HIT/MISS/EXPIRED/etc) for debugging
@@ -167,6 +194,7 @@ data:
 
             # Default location: proxy to the upstream server without caching.
             # Handles paths not matching any allowList patterns.
+            # Redirects are passed through as-is (not intercepted).
             location / {
                 proxy_pass $upstream_url;
                 proxy_set_header Host {{ (urlParse .Values.nginx.upstream.url).host }};

--- a/squid/values.schema.json
+++ b/squid/values.schema.json
@@ -704,6 +704,10 @@
               "type": "integer",
               "minimum": 1,
               "description": "Cache size in megabytes"
+            },
+            "ttl": {
+              "type": "string",
+              "description": "Cache TTL for responses (nginx time format: 1d, 12h, 30m)"
             }
           },
           "additionalProperties": false

--- a/squid/values.yaml
+++ b/squid/values.yaml
@@ -463,6 +463,8 @@ nginx:
     allowList: []
     # Cache size in megabytes
     size: 1024
+    # How long cached responses are considered fresh (nginx time format: 1d, 12h, 30m)
+    ttl: "1d"
 
   # Image configuration
   image: registry.access.redhat.com/ubi10/nginx-126@sha256:77d9ff8c889d48f1f068d0599f115b797154c5a14bb0fb57d45f809e4a244245

--- a/tests/e2e/nginx_proxy_test.go
+++ b/tests/e2e/nginx_proxy_test.go
@@ -70,42 +70,27 @@ var _ = Describe("Nginx Proxy Caching Tests", Label("nginx"), Ordered, Serial, f
 			"Request to backend should succeed")
 	})
 
-	It("should return X-Cache-Status: MISS on first request", func() {
-		reqURL := testhelpers.GetNginxURL() + "/content/test?" + generateCacheBuster("nginx-cache-miss")
+	It("should contact upstream on every request for allowList paths", func() {
+		reqURL := testhelpers.GetNginxURL() + "/content/test?" + generateCacheBuster("always-upstream")
 
-		resp, err := client.Get(reqURL)
-		Expect(err).NotTo(HaveOccurred())
-		defer resp.Body.Close()
-
-		cacheStatus := resp.Header.Get("X-Cache-Status")
-		Expect(cacheStatus).To(Equal("MISS"),
-			"First request should be a cache MISS")
-	})
-
-	It("should return X-Cache-Status: HIT on repeated request", func() {
-		reqURL := testhelpers.GetNginxURL() + "/content/test?" + generateCacheBuster("nginx-cache-hit")
-
-		// First request - should be MISS
+		// Make two requests to the same URL — both should return fresh
+		// responses from the upstream since allowList locations don't cache directly
 		resp1, err := client.Get(reqURL)
 		Expect(err).NotTo(HaveOccurred())
 		body1, err := io.ReadAll(resp1.Body)
 		Expect(err).NotTo(HaveOccurred())
 		resp1.Body.Close()
-		Expect(resp1.Header.Get("X-Cache-Status")).To(Equal("MISS"),
-			"First request should be a cache MISS")
 
-		// Second request - should be HIT
 		resp2, err := client.Get(reqURL)
 		Expect(err).NotTo(HaveOccurred())
 		body2, err := io.ReadAll(resp2.Body)
 		Expect(err).NotTo(HaveOccurred())
 		resp2.Body.Close()
-		Expect(resp2.Header.Get("X-Cache-Status")).To(Equal("HIT"),
-			"Second request should be a cache HIT")
 
-		// Verify response bodies are identical
-		Expect(body2).To(Equal(body1),
-			"Cached response should match original response")
+		// The server_hits counter should differ, proving both requests
+		// reached the upstream rather than being served from cache
+		Expect(body2).NotTo(Equal(body1),
+			"Responses should differ because each request contacts the upstream")
 	})
 
 	It("should NOT cache requests to non-matching paths", func() {

--- a/tests/e2e/nginx_redirect_test.go
+++ b/tests/e2e/nginx_redirect_test.go
@@ -1,6 +1,7 @@
 package e2e_test
 
 import (
+	"io"
 	"net/http"
 	"net/url"
 
@@ -9,8 +10,11 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Upstream Redirect Tests", Label("nginx"), Ordered, Serial, func() {
-	var backendURL string
+var _ = Describe("Nginx Redirect Interception Tests", Label("nginx"), Ordered, Serial, func() {
+	var (
+		backendURL string
+		client     *http.Client
+	)
 
 	BeforeAll(func() {
 		backendURL = testhelpers.GetNginxTestBackendURL()
@@ -21,30 +25,89 @@ var _ = Describe("Upstream Redirect Tests", Label("nginx"), Ordered, Serial, fun
 				Upstream: &testhelpers.NginxUpstreamValues{
 					URL: backendURL,
 				},
+				Cache: &testhelpers.NginxCacheValues{
+					AllowList: []string{"^/redirect"},
+				},
 			},
 		})
 		Expect(err).NotTo(HaveOccurred())
+
+		client = testhelpers.NewNginxClient()
 	})
 
-	It("should return a 302 redirect from the redirect endpoint", func() {
+	It("should follow redirects internally and return 200 to the client", func() {
 		targetURL := backendURL + "/content/test"
-		redirectURL := backendURL + "/redirect?url=" + url.QueryEscape(targetURL)
+		reqURL := testhelpers.GetNginxURL() + "/redirect?url=" + url.QueryEscape(targetURL)
 
-		client := &http.Client{
-			CheckRedirect: func(req *http.Request, via []*http.Request) error {
-				return http.ErrUseLastResponse
-			},
-		}
-
-		resp, err := client.Get(redirectURL)
+		resp, err := client.Get(reqURL)
 		Expect(err).NotTo(HaveOccurred())
 		defer resp.Body.Close()
 
-		Expect(resp.StatusCode).To(Equal(http.StatusFound),
-			"Redirect endpoint should return 302")
+		Expect(resp.StatusCode).To(Equal(http.StatusOK),
+			"Nginx should follow the redirect and return 200, not 302")
 
-		location := resp.Header.Get("Location")
-		Expect(location).To(Equal(targetURL),
-			"Location header should point to the target URL")
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(body)).To(BeNumerically(">", 0),
+			"Response body should contain the redirect target's content")
+	})
+
+	It("should cache redirected content with MISS then HIT", func() {
+		targetURL := backendURL + "/content/cache-test"
+		reqURL := testhelpers.GetNginxURL() + "/redirect?url=" + url.QueryEscape(targetURL) + "&" + generateCacheBuster("redirect-cache")
+
+		// First request - should be MISS
+		resp1, err := client.Get(reqURL)
+		Expect(err).NotTo(HaveOccurred())
+		body1, err := io.ReadAll(resp1.Body)
+		Expect(err).NotTo(HaveOccurred())
+		resp1.Body.Close()
+		Expect(resp1.StatusCode).To(Equal(http.StatusOK))
+		Expect(resp1.Header.Get("X-Cache-Status")).To(Equal("MISS"),
+			"First request should be a cache MISS")
+
+		// Second request - should be HIT
+		resp2, err := client.Get(reqURL)
+		Expect(err).NotTo(HaveOccurred())
+		body2, err := io.ReadAll(resp2.Body)
+		Expect(err).NotTo(HaveOccurred())
+		resp2.Body.Close()
+		Expect(resp2.StatusCode).To(Equal(http.StatusOK))
+		Expect(resp2.Header.Get("X-Cache-Status")).To(Equal("HIT"),
+			"Second request should be a cache HIT")
+
+		Expect(body2).To(Equal(body1),
+			"Cached response should match original response")
+	})
+
+	It("should pass through 403 from upstream even when content is cached", func() {
+		targetURL := backendURL + "/content/ban-test"
+		reqURL := testhelpers.GetNginxURL() + "/redirect?url=" + url.QueryEscape(targetURL) + "&" + generateCacheBuster("ban-test")
+
+		// First request - should succeed and cache
+		resp1, err := client.Get(reqURL)
+		Expect(err).NotTo(HaveOccurred())
+		resp1.Body.Close()
+		Expect(resp1.StatusCode).To(Equal(http.StatusOK),
+			"First request should succeed")
+
+		// Second request - should be cached
+		resp2, err := client.Get(reqURL)
+		Expect(err).NotTo(HaveOccurred())
+		resp2.Body.Close()
+		Expect(resp2.StatusCode).To(Equal(http.StatusOK),
+			"Second request should succeed from cache")
+		Expect(resp2.Header.Get("X-Cache-Status")).To(Equal("HIT"))
+
+		// Third request with ban header - upstream should return 403
+		req, err := http.NewRequest(http.MethodGet, reqURL, nil)
+		Expect(err).NotTo(HaveOccurred())
+		req.Header.Set("X-Response-Status", "403")
+
+		resp3, err := client.Do(req)
+		Expect(err).NotTo(HaveOccurred())
+		resp3.Body.Close()
+		Expect(resp3.StatusCode).To(Equal(http.StatusForbidden),
+			"Banned request should return 403, not cached 200")
 	})
 })

--- a/tests/helm/nginx_template_test.go
+++ b/tests/helm/nginx_template_test.go
@@ -279,9 +279,9 @@ var _ = Describe("Helm Template Nginx Configuration", func() {
 			Expect(configMap).To(ContainSubstring("location ~ ^/repository/npm-.*"), "Should have npm pattern cached location")
 			Expect(configMap).To(ContainSubstring("location ~ \\.tar\\.gz$"), "Should have tar.gz pattern cached location")
 
-			// Verify each cached location has cache directives
-			Expect(strings.Count(configMap, "proxy_cache backend_cache")).To(Equal(3), "Should have proxy_cache in 3 locations")
-			Expect(strings.Count(configMap, "proxy_cache_valid 200 1d")).To(Equal(3), "Should have cache_valid in 3 locations")
+			// Caching only happens in @handle_redirect, not in allowList locations
+			Expect(strings.Count(configMap, "proxy_cache backend_cache")).To(Equal(1), "Should have proxy_cache only in @handle_redirect")
+			Expect(strings.Count(configMap, "proxy_cache_valid 200 1d")).To(Equal(1), "Should have cache_valid only in @handle_redirect")
 
 			// Verify default location still exists
 			Expect(configMap).To(ContainSubstring("location / {"), "Should still have default location")
@@ -309,6 +309,110 @@ var _ = Describe("Helm Template Nginx Configuration", func() {
 
 			// Auth header should appear in both cached location and default location
 			Expect(strings.Count(configMap, `proxy_set_header Authorization "__AUTH_HEADER__"`)).To(Equal(2), "Should have auth header in both locations")
+		})
+
+		It("should render @handle_redirect when allowList has entries", func() {
+			output, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{
+				Nginx: &testhelpers.NginxValues{
+					Enabled: true,
+					Upstream: &testhelpers.NginxUpstreamValues{
+						URL: "http://backend:8080",
+					},
+					Cache: &testhelpers.NginxCacheValues{
+						AllowList: []string{`^/content/`},
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			configMap := extractNginxConfigMapSection(output)
+
+			Expect(configMap).To(ContainSubstring("location @handle_redirect"), "Should render @handle_redirect")
+			Expect(configMap).To(ContainSubstring("set $redirect_url $upstream_http_location"), "Should capture redirect URL")
+			Expect(configMap).To(ContainSubstring("proxy_ssl_server_name on"), "Should enable SNI for redirect targets")
+			Expect(configMap).To(ContainSubstring(`proxy_cache_key "$scheme$host$request_uri"`), "Should cache on original request URI")
+		})
+
+		It("should NOT render @handle_redirect when allowList is empty", func() {
+			output, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{
+				Nginx: &testhelpers.NginxValues{
+					Enabled: true,
+					Upstream: &testhelpers.NginxUpstreamValues{
+						URL: "http://backend:8080",
+					},
+					Cache: &testhelpers.NginxCacheValues{
+						AllowList: []string{},
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			configMap := extractNginxConfigMapSection(output)
+
+			Expect(configMap).NotTo(ContainSubstring("@handle_redirect"), "Should not render @handle_redirect without allowList")
+			Expect(configMap).NotTo(ContainSubstring("proxy_intercept_errors"), "Should not have redirect interception without allowList")
+		})
+
+		It("should add redirect interception to allowList locations", func() {
+			output, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{
+				Nginx: &testhelpers.NginxValues{
+					Enabled: true,
+					Upstream: &testhelpers.NginxUpstreamValues{
+						URL: "http://backend:8080",
+					},
+					Cache: &testhelpers.NginxCacheValues{
+						AllowList: []string{`^/content/`},
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			configMap := extractNginxConfigMapSection(output)
+
+			Expect(configMap).To(ContainSubstring("proxy_intercept_errors on"), "AllowList location should intercept errors")
+			Expect(configMap).To(ContainSubstring("error_page 301 302 307 308 = @handle_redirect"), "AllowList location should redirect to @handle_redirect")
+		})
+
+		It("should use configured TTL in cache directives", func() {
+			output, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{
+				Nginx: &testhelpers.NginxValues{
+					Enabled: true,
+					Upstream: &testhelpers.NginxUpstreamValues{
+						URL: "http://backend:8080",
+					},
+					Cache: &testhelpers.NginxCacheValues{
+						AllowList: []string{`^/content/`},
+						TTL:       "30d",
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			configMap := extractNginxConfigMapSection(output)
+
+			Expect(configMap).To(ContainSubstring("proxy_cache_valid 200 30d"), "Should use configured TTL")
+			Expect(configMap).NotTo(ContainSubstring("proxy_cache_valid 200 1d"), "Should not have default TTL")
+		})
+
+		It("should not have redirect interception in default location", func() {
+			output, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{
+				Nginx: &testhelpers.NginxValues{
+					Enabled: true,
+					Upstream: &testhelpers.NginxUpstreamValues{
+						URL: "http://backend:8080",
+					},
+					Cache: &testhelpers.NginxCacheValues{
+						AllowList: []string{`^/content/`},
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			configMap := extractNginxConfigMapSection(output)
+
+			// Default location should still bypass cache
+			Expect(configMap).To(ContainSubstring("proxy_no_cache 1"), "Default location should bypass cache")
+			Expect(configMap).To(ContainSubstring(`"BYPASS"`), "Default location should show BYPASS")
 		})
 	})
 

--- a/tests/nginx-test-backend/main.go
+++ b/tests/nginx-test-backend/main.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"sync/atomic"
 	"time"
 )
@@ -18,6 +19,22 @@ func main() {
 	expectedAuth := os.Getenv("EXPECTED_AUTH")
 
 	var requestCount int32
+
+	// checkOverrideStatus returns true (and writes the response) if the client
+	// requested a specific status code via X-Response-Status header.
+	checkOverrideStatus := func(w http.ResponseWriter, r *http.Request) bool {
+		val := r.Header.Get("X-Response-Status")
+		if val == "" {
+			return false
+		}
+		code, err := strconv.Atoi(val)
+		if err != nil || code < 100 || code > 599 {
+			http.Error(w, "invalid X-Response-Status value", http.StatusBadRequest)
+			return true
+		}
+		http.Error(w, http.StatusText(code), code)
+		return true
+	}
 
 	checkAuth := func(w http.ResponseWriter, r *http.Request) bool {
 		if expectedAuth == "" {
@@ -46,6 +63,9 @@ func main() {
 		if !checkAuth(w, r) {
 			return
 		}
+		if checkOverrideStatus(w, r) {
+			return
+		}
 		target := r.URL.Query().Get("url")
 		if target == "" {
 			http.Error(w, "missing 'url' query parameter", http.StatusBadRequest)
@@ -57,6 +77,9 @@ func main() {
 
 	mux.HandleFunc("/content/", func(w http.ResponseWriter, r *http.Request) {
 		if !checkAuth(w, r) {
+			return
+		}
+		if checkOverrideStatus(w, r) {
 			return
 		}
 

--- a/tests/testhelpers/nginx_helpers.go
+++ b/tests/testhelpers/nginx_helpers.go
@@ -58,6 +58,7 @@ type NginxAuthValues struct {
 type NginxCacheValues struct {
 	AllowList []string `json:"allowList,omitempty"`
 	Size      int      `json:"size,omitempty"`
+	TTL       string   `json:"ttl,omitempty"`
 }
 
 // NginxServiceValues holds service configuration


### PR DESCRIPTION
Nginx now intercepts 301/302/307 redirects from the upstream via proxy_intercept_errors and follows them internally through a @handle_redirect named location. The redirect target response is cached keyed on the original request URI, so subsequent requests for the same artifact are served from cache without re-fetching the redirect target.

Only redirect target responses are cached. AllowList locations do NOT cache responses directly — the upstream is always contacted on every request so it can enforce authorization (e.g. return 403 for banned packages). This ensures bans take effect immediately even when the redirect target content is cached.

Redirect interception only applies to allowList locations. The default location passes redirects through to the client as-is, consistent with its no-caching behavior.

The redirect target cache TTL is configurable via nginx.cache.ttl (default 1d). The previously hardcoded proxy_cache_valid in the allowList location has been removed along with all direct caching at that level.

The nginx-test-backend gains an X-Response-Status header that lets e2e tests simulate any upstream response code (e.g. 403 for ban enforcement) without redeploying.

Jira issues: KFLUXVNGD-997, KFLUXVNGD-998

Assisted-by: Claude claude-opus-4-6

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [x] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
