### PR TITLE
fix: remove HTTP GET verification from store-id helper

### DIFF
--- a/cmd/squid-store-id/main.go
+++ b/cmd/squid-store-id/main.go
@@ -5,17 +5,11 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net/http"
 	"os"
 	"strconv"
 	"strings"
 	"sync"
 )
-
-// HTTPClient interface for making HTTP requests (allows mocking)
-type HTTPClient interface {
-	Get(url string) (*http.Response, error)
-}
 
 // isChannelID checks if a string represents a positive integer (for channel-ID detection)
 func isChannelID(s string) bool {
@@ -23,39 +17,17 @@ func isChannelID(s string) bool {
 	return err == nil && val >= 0
 }
 
-// normalizeStoreID normalizes the store-id for caching by removing query parameters from CDN URLs.
-// Only content-addressable URLs (containing SHA256 hashes) are normalized.
-// The request URL must return a 200 status code to ensure the request is authorized.
-func normalizeStoreID(client HTTPClient, requestURL string) string {
-	// Only normalize content-addressable URLs (those with SHA256 hashes in the path).
-	// This prevents breaking caching for arbitrary URLs with meaningful query parameters.
+func normalizeStoreID(requestURL string) string {
 	if !strings.Contains(requestURL, "/sha256/") {
 		return requestURL
 	}
-
-	// Issue the request to the CDN/S3 to check authorization but don't read the body
-	resp, err := client.Get(requestURL)
-	if err != nil {
-		// Don't log the request URL to avoid leaking sensitive information
-		log.Printf("Error getting URL: %v", err)
-		return requestURL
-	}
-
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		log.Printf("Error getting URL, status code: %v", resp.StatusCode)
-		return requestURL
-	}
-
-	// Return the URL without query parameters as the cache key
 	return strings.SplitN(requestURL, "?", 2)[0]
 }
 
 // parseLine parses the input line according to Squid protocol:
 // [channel-ID <SP>] request-URL [<SP> extras] <NL>
 // and returns the response for Squid.
-func parseLine(line string, normalizeFunc func(HTTPClient, string) string) string {
+func parseLine(line string, normalizeFunc func(string) string) string {
 	parts := strings.Fields(line)
 
 	var requestURL string
@@ -70,7 +42,7 @@ func parseLine(line string, normalizeFunc func(HTTPClient, string) string) strin
 	requestURL = parts[0]
 
 	// Normalize the store-id for caching
-	storeID := normalizeFunc(http.DefaultClient, requestURL)
+	storeID := normalizeFunc(requestURL)
 
 	if storeID != requestURL {
 		// Return the normalized store-id for caching
@@ -83,7 +55,7 @@ func parseLine(line string, normalizeFunc func(HTTPClient, string) string) strin
 }
 
 // processInput reads lines from in, processes each concurrently, and writes responses to out
-func processInput(in io.Reader, out io.Writer, normalizeFunc func(HTTPClient, string) string) error {
+func processInput(in io.Reader, out io.Writer, normalizeFunc func(string) string) error {
 	scanner := bufio.NewScanner(in)
 
 	// Use a wait group to ensure all goroutines gracefully exit

--- a/cmd/squid-store-id/main_test.go
+++ b/cmd/squid-store-id/main_test.go
@@ -3,8 +3,6 @@ package main
 import (
 	"bytes"
 	"io"
-	"net/http"
-	"net/url"
 	"strings"
 	"sync"
 
@@ -36,8 +34,8 @@ var _ = Describe("isChannelID", func() {
 })
 
 var _ = Describe("parseLine", func() {
-	var normalizeFunc = func(client HTTPClient, url string) string { return url }
-	var normalizeFuncDifferent = func(client HTTPClient, url string) string { return "normalized-" + url }
+	var normalizeFunc = func(url string) string { return url }
+	var normalizeFuncDifferent = func(url string) string { return "normalized-" + url }
 
 	When("given a line with a channel-ID", func() {
 		Context("and the normalized store-id is different from the original URL", func() {
@@ -74,42 +72,28 @@ var _ = Describe("parseLine", func() {
 
 var _ = Describe("normalizeStoreID", func() {
 	When("given content-addressable URLs with query parameters", func() {
-		const testURL = "https://cdn.example.com/blobs/sha256/ab/abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890?token=abc123&expires=456"
-
-		It("should return normalized URL (without query params) when HTTP request succeeds", func() {
-			mockClient := &MockHTTPClient{
-				StatusCode: http.StatusOK,
-			}
-
+		It("should strip query params from URLs containing /sha256/", func() {
+			testURL := "https://cdn.example.com/blobs/sha256/ab/abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890?token=abc123&expires=456"
 			expectedURL := "https://cdn.example.com/blobs/sha256/ab/abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
-			Expect(normalizeStoreID(mockClient, testURL)).To(Equal(expectedURL))
+			Expect(normalizeStoreID(testURL)).To(Equal(expectedURL))
 		})
 
-		It("should handle non-200 HTTP responses by returning original URL", func() {
-			mockClient := &MockHTTPClient{
-				StatusCode: http.StatusUnauthorized,
-			}
-
-			Expect(normalizeStoreID(mockClient, testURL)).To(Equal(testURL))
+		It("should return unchanged URL when no query params present", func() {
+			testURL := "https://cdn.example.com/blobs/sha256/ab/abcdef1234567890"
+			Expect(normalizeStoreID(testURL)).To(Equal(testURL))
 		})
+	})
 
-		It("should handle HTTP error responses by returning original URL", func() {
-			mockClient := &MockHTTPClient{
-				ShouldError: true,
-				Error: &url.Error{
-					Op:  "Get",
-					URL: testURL,
-					Err: http.ErrServerClosed,
-				},
-			}
-
-			Expect(normalizeStoreID(mockClient, testURL)).To(Equal(testURL))
+	When("given non-content-addressable URLs", func() {
+		It("should return the original URL unchanged", func() {
+			testURL := "https://example.com/path?query=value"
+			Expect(normalizeStoreID(testURL)).To(Equal(testURL))
 		})
 	})
 })
 
 var _ = Describe("processInput", func() {
-	var normalizeFuncDifferent = func(client HTTPClient, url string) string { return "normalized-" + url }
+	var normalizeFuncDifferent = func(url string) string { return "normalized-" + url }
 
 	It("processes multiple lines concurrently", func() {
 		in := strings.NewReader(
@@ -144,28 +128,6 @@ var _ = Describe("processInput", func() {
 		Expect(err).To(MatchError(io.ErrUnexpectedEOF))
 	})
 })
-
-// MockHTTPClient implements HTTPClient interface for testing
-type MockHTTPClient struct {
-	StatusCode  int
-	ShouldError bool
-	Error       error
-}
-
-func (m *MockHTTPClient) Get(url string) (*http.Response, error) {
-	if m.ShouldError {
-		return nil, m.Error
-	}
-
-	// Create a mock response
-	resp := &http.Response{
-		StatusCode: m.StatusCode,
-		Body:       io.NopCloser(strings.NewReader("")), // Empty body
-		Header:     make(http.Header),
-	}
-
-	return resp, nil
-}
 
 // MockWriter implements io.Writer for testing
 type MockWriter struct {


### PR DESCRIPTION
The store-id helper was making HTTP GET requests to CDN URLs to verify they return 200 before stripping query parameters. This caused flaky cache misses when CDN tokens were expired or consumed, preventing cache key normalization. Since /sha256/ URLs are content-addressable, query parameters are always auth tokens — stripping them is always safe.


Assisted-by: Claude Opus 4.6 (via Claude Code)

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [x] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
