### PR TITLE
fix(KFLUXVNGD-994): Fix cache size rendering for large values

### DIFF
--- a/squid/templates/deployment.yaml
+++ b/squid/templates/deployment.yaml
@@ -238,5 +238,5 @@ spec:
         accessModes: [ "ReadWriteOnce" ]
         resources:
           requests:
-            storage: {{ .Values.cache.size }}Mi
+            storage: {{ int .Values.cache.size }}Mi
 {{- end }}

--- a/squid/templates/nginx-configmap.yaml
+++ b/squid/templates/nginx-configmap.yaml
@@ -65,7 +65,7 @@ data:
         # - use_temp_path=off: Write directly to cache dir (faster, avoids copy)
         proxy_cache_path /var/cache/nginx levels=1:2
                          keys_zone=backend_cache:10m
-                         max_size={{ .Values.nginx.cache.size }}m
+                         max_size={{ int .Values.nginx.cache.size }}m
                          inactive=7d
                          use_temp_path=off;
 

--- a/squid/templates/nginx-statefulset.yaml
+++ b/squid/templates/nginx-statefulset.yaml
@@ -207,5 +207,5 @@ spec:
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:
-            storage: {{ .Values.nginx.cache.size }}Mi
+            storage: {{ int .Values.nginx.cache.size }}Mi
 {{- end }}


### PR DESCRIPTION
Cast cache size values to int in helm templates to prevent Go's default float formatting from rendering values >= 1M in scientific notation (e.g. 1.048576e+06Mi), which Kubernetes rejects.

Jira-Url: https://redhat.atlassian.net/browse/KFLUXVNGD-994
Assisted-by: Claude Code

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [x] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
