### PR TITLE
feat(KFLUXVNGD-1012): add AI skills for testing, debugging, and cluster setup

### DIFF
--- a/skills/debugging-running-instance/SKILL.md
+++ b/skills/debugging-running-instance/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: debugging-running-instance
+description: Gotchas when debugging a deployed Squid instance
+---
+
+# Debugging Running Instances
+
+- The chart deploys **both Squid and Nginx** -- use label selectors (`app.kubernetes.io/component=squid-caching` or `nginx-caching`) to find the right pods
+- Cache auto-cleans when disk usage **exceeds 95%** on container start -- if cache is empty after restart, check `CACHE_USAGE_THRESHOLD` env var
+- Unexpected pod restarts may be **certificate rotation**, not crashes -- the entrypoint watches `/etc/squid/certs/tls.crt` every 30s and exits when the cert changes

--- a/skills/kind-cluster-setup/SKILL.md
+++ b/skills/kind-cluster-setup/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: kind-cluster-setup
+description: Gotchas when setting up or tearing down the local kind cluster
+---
+
+# Managing Kind Clusters
+
+- `kind load` calls `podman save` under the hood -- if it hangs, check the Podman socket (`systemctl --user status podman.socket`)
+- `mage clean` also deletes squid and test images, not just the cluster -- re-running `mage all` afterwards rebuilds from scratch
+- `mage kind:upClean` destroys deployed workloads and persistent volumes -- use `mage kind:up` if you only need to re-export kubeconfig

--- a/skills/running-tests/SKILL.md
+++ b/skills/running-tests/SKILL.md
@@ -1,0 +1,9 @@
+---
+name: running-tests
+description: Gotchas when running unit or E2E tests
+---
+
+# Running Tests
+
+- `mage all` and `mage test:cluster` fail differently: `helm test` failures appear in pod logs (`kubectl logs squid-test-...`), while `test:cluster` failures require a working mirrord binary and an active target pod -- check the latter first if tests hang
+- After cluster tests, Helm release is **reset to defaults** automatically -- don't rely on test-modified state persisting

--- a/skills/updating-go-deps/SKILL.md
+++ b/skills/updating-go-deps/SKILL.md
@@ -7,4 +7,4 @@ description: Gotchas when updating Go dependencies
 
 - `go.mod` has a **replace** directive for access-log-exporter (points to a fork)
 - `tools.go` must import build/test-only deps — required for Cachi2 hermetic prefetch
-- After changes: run `go mod tidy` then update lockfiles per [HERMETIC-BUILDS.md](../HERMETIC-BUILDS.md)
+- After changes: run `go mod tidy` then update lockfiles per [HERMETIC-BUILDS.md](../../HERMETIC-BUILDS.md)


### PR DESCRIPTION
Add three gotcha-focused skills covering running tests, debugging deployed instances, and managing kind clusters. Fix broken HERMETIC-BUILDS.md link in updating-go-deps skill.

Jira-Url: https://redhat.atlassian.net/browse/KFLUXVNGD-1012
Assisted-by: Claude Opus 4.6 (via Claude Code)

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [x] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
