### PR TITLE
refactor(KFLUXVNGD-1052): rename chart template helpers to caching.* pattern

### DIFF
--- a/caching/templates/_helpers.tpl
+++ b/caching/templates/_helpers.tpl
@@ -1,22 +1,35 @@
 {{/*
 =============================================================================
-SQUID HELPERS
+CHART-LEVEL HELPERS
 =============================================================================
 */}}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "squid.chart" -}}
+{{- define "caching.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
-Common labels
+Get current environment - defaults to "release" if not set
 */}}
-{{- define "squid.labels" -}}
-helm.sh/chart: {{ include "squid.chart" . }}
-{{ include "squid.selectorLabels" . }}
+{{- define "caching.environment" -}}
+{{- .Values.environment | default "release" -}}
+{{- end }}
+
+{{/*
+=============================================================================
+SQUID COMPONENT HELPERS
+=============================================================================
+*/}}
+
+{{/*
+Common labels for Squid component
+*/}}
+{{- define "caching.squid.labels" -}}
+helm.sh/chart: {{ include "caching.chart" . }}
+{{ include "caching.squid.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -24,9 +37,10 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
-Selector labels
+Selector labels for Squid component
+NOTE: Values remain 'squid' - these are runtime identifiers, not chart names
 */}}
-{{- define "squid.selectorLabels" -}}
+{{- define "caching.squid.selectorLabels" -}}
 app.kubernetes.io/name: {{ .Values.squid.name }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/component: squid-caching
@@ -35,7 +49,7 @@ app.kubernetes.io/component: squid-caching
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "squid.serviceAccountName" -}}
+{{- define "caching.squid.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
 {{- default .Values.squid.name .Values.serviceAccount.name }}
 {{- else }}
@@ -44,17 +58,10 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Get current environment - defaults to "release" if not set
-*/}}
-{{- define "squid.environment" -}}
-{{- .Values.environment | default "release" -}}
-{{- end }}
-
-{{/*
 Get squid image for current environment
 */}}
-{{- define "squid.image" -}}
-{{- $env := include "squid.environment" . -}}
+{{- define "caching.squid.image" -}}
+{{- $env := include "caching.environment" . -}}
 {{- $envSettings := index .Values.envSettings $env -}}
 {{- if hasPrefix "sha256:" $envSettings.squid.image.tag -}}
   {{- printf "%s@%s" $envSettings.squid.image.repository $envSettings.squid.image.tag -}}
@@ -66,8 +73,8 @@ Get squid image for current environment
 {{/*
 Get test image for current environment
 */}}
-{{- define "squid.test.image" -}}
-{{- $env := include "squid.environment" . -}}
+{{- define "caching.test.image" -}}
+{{- $env := include "caching.environment" . -}}
 {{- $envSettings := index .Values.envSettings $env -}}
 {{- if hasPrefix "sha256:" $envSettings.test.image.tag -}}
   {{- printf "%s@%s" $envSettings.test.image.repository $envSettings.test.image.tag -}}
@@ -77,31 +84,31 @@ Get test image for current environment
 {{- end }}
 
 {{/*
-Default affinity rules when none are specified
+Default affinity rules for Squid when none are specified
 */}}
-{{- define "squid.defaultAffinity" -}}
+{{- define "caching.squid.defaultAffinity" -}}
 podAntiAffinity:
   preferredDuringSchedulingIgnoredDuringExecution:
   - weight: 100
     podAffinityTerm:
       labelSelector:
         matchLabels:
-          {{- include "squid.selectorLabels" . | nindent 10 }}
+          {{- include "caching.squid.selectorLabels" . | nindent 10 }}
       topologyKey: kubernetes.io/hostname
 {{- end }}
 
 {{/*
 =============================================================================
-NGINX HELPERS
+NGINX COMPONENT HELPERS
 =============================================================================
 */}}
 
 {{/*
-Common labels
+Common labels for Nginx component
 */}}
-{{- define "nginx.labels" -}}
-helm.sh/chart: {{ include "squid.chart" . }}
-{{ include "nginx.selectorLabels" . }}
+{{- define "caching.nginx.labels" -}}
+helm.sh/chart: {{ include "caching.chart" . }}
+{{ include "caching.nginx.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -109,33 +116,34 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
-Selector labels
+Selector labels for Nginx component
+NOTE: Values remain 'nginx' - these are runtime identifiers, not chart names
 */}}
-{{- define "nginx.selectorLabels" -}}
+{{- define "caching.nginx.selectorLabels" -}}
 app.kubernetes.io/name: {{ .Values.nginx.name }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/component: nginx-caching
 {{- end }}
 
 {{/*
-Default affinity rules when none are specified
+Default affinity rules for Nginx when none are specified
 */}}
-{{- define "nginx.defaultAffinity" -}}
+{{- define "caching.nginx.defaultAffinity" -}}
 podAntiAffinity:
   preferredDuringSchedulingIgnoredDuringExecution:
   - weight: 100
     podAffinityTerm:
       labelSelector:
         matchLabels:
-          {{- include "nginx.selectorLabels" . | nindent 10 }}
+          {{- include "caching.nginx.selectorLabels" . | nindent 10 }}
       topologyKey: kubernetes.io/hostname
 {{- end }}
 
 {{/*
 Get nginx exporter image for current environment
 */}}
-{{- define "nginx.exporter.image" -}}
-{{- $env := include "squid.environment" . -}}
+{{- define "caching.nginx.exporter.image" -}}
+{{- $env := include "caching.environment" . -}}
 {{- $envSettings := index .Values.envSettings $env -}}
 {{- if hasPrefix "sha256:" $envSettings.nginx.exporter.image.tag -}}
   {{- printf "%s@%s" $envSettings.nginx.exporter.image.repository $envSettings.nginx.exporter.image.tag -}}

--- a/caching/templates/configmap.yaml
+++ b/caching/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.squid.name }}-config
   namespace: {{ .Values.namespace.name }}
   labels:
-    {{- include "squid.labels" . | nindent 4 }}
+    {{- include "caching.squid.labels" . | nindent 4 }}
 data:
   squid.conf: |-
     # This is a minimal squid configuration file

--- a/caching/templates/deployment.yaml
+++ b/caching/templates/deployment.yaml
@@ -5,13 +5,13 @@ metadata:
   name: {{ .Values.squid.name }}
   namespace: {{ .Values.namespace.name }}
   labels:
-    {{- include "squid.labels" . | nindent 4 }}
+    {{- include "caching.squid.labels" . | nindent 4 }}
 spec:
   serviceName: {{ .Values.squid.name }}-headless
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      {{- include "squid.selectorLabels" . | nindent 6 }}
+      {{- include "caching.squid.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
@@ -21,13 +21,13 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "squid.selectorLabels" . | nindent 8 }}
+        {{- include "caching.squid.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "squid.serviceAccountName" . }}
+      serviceAccountName: {{ include "caching.squid.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
 
@@ -35,7 +35,7 @@ spec:
         - name: squid
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ include "squid.image" . }}"
+          image: "{{ include "caching.squid.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
@@ -106,7 +106,7 @@ spec:
         - name: icap-server
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ include "squid.image" . }}"
+          image: "{{ include "caching.squid.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: icap
@@ -126,7 +126,7 @@ spec:
         - name: squid-exporter
           securityContext:
             {{- toYaml .Values.squidExporter.securityContext | nindent 12 }}
-          image: "{{ include "squid.image" . }}"
+          image: "{{ include "caching.squid.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: metrics
@@ -225,7 +225,7 @@ spec:
       {{- end }}
       {{- else }}
       affinity:
-        {{- include "squid.defaultAffinity" . | nindent 8 }}
+        {{- include "caching.squid.defaultAffinity" . | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:

--- a/caching/templates/headless-service.yaml
+++ b/caching/templates/headless-service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.squid.name }}-headless
   namespace: {{ .Values.namespace.name }}
   labels:
-    {{- include "squid.labels" . | nindent 4 }}
+    {{- include "caching.squid.labels" . | nindent 4 }}
 spec:
   clusterIP: None
   ports:
@@ -26,5 +26,5 @@ spec:
       name: per-site-http
     {{- end }}
   selector:
-    {{- include "squid.selectorLabels" . | nindent 4 }}
+    {{- include "caching.squid.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/caching/templates/mirrord-target-pod.yaml
+++ b/caching/templates/mirrord-target-pod.yaml
@@ -12,13 +12,13 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/component: mirrord-target
     app: {{ .Values.mirrord.targetPod.name }}
-    helm.sh/chart: {{ include "squid.chart" . }}
+    helm.sh/chart: {{ include "caching.chart" . }}
 spec:
   serviceAccountName: {{ .Values.squid.name }}-test
   restartPolicy: Always  # Keep the target pod running for development
   containers:
     - name: mirrord-target
-      image: "{{ include "squid.test.image" . }}"
+      image: "{{ include "caching.test.image" . }}"
       imagePullPolicy: {{ .Values.mirrord.targetPod.image.pullPolicy | default "IfNotPresent" }}
       command: ["/app/mirrord-target"]
       ports:

--- a/caching/templates/nginx-configmap.yaml
+++ b/caching/templates/nginx-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.nginx.name }}-config
   namespace: {{ .Values.namespace.name }}
   labels:
-    {{- include "nginx.labels" . | nindent 4 }}
+    {{- include "caching.nginx.labels" . | nindent 4 }}
 data:
   nginx.conf: |
     # Automatically spawn one worker process per CPU core for optimal performance

--- a/caching/templates/nginx-exporter-configmap.yaml
+++ b/caching/templates/nginx-exporter-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.nginx.name }}-exporter-config
   namespace: {{ .Values.namespace.name }}
   labels:
-    {{- include "nginx.labels" . | nindent 4 }}
+    {{- include "caching.nginx.labels" . | nindent 4 }}
 data:
   config.yaml: |
     # access-log-exporter configuration

--- a/caching/templates/nginx-headless-service.yaml
+++ b/caching/templates/nginx-headless-service.yaml
@@ -5,11 +5,11 @@ metadata:
   name: {{ .Values.nginx.name }}-headless
   namespace: {{ .Values.namespace.name }}
   labels:
-    {{- include "nginx.labels" . | nindent 4 }}
+    {{- include "caching.nginx.labels" . | nindent 4 }}
 spec:
   clusterIP: None
   selector:
-    {{- include "nginx.selectorLabels" . | nindent 4 }}
+    {{- include "caching.nginx.selectorLabels" . | nindent 4 }}
   ports:
     - port: {{ .Values.nginx.service.port }}
       protocol: TCP

--- a/caching/templates/nginx-service.yaml
+++ b/caching/templates/nginx-service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.nginx.name }}
   namespace: {{ .Values.namespace.name }}
   labels:
-    {{- include "nginx.labels" . | nindent 4 }}
+    {{- include "caching.nginx.labels" . | nindent 4 }}
   {{- with .Values.nginx.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -16,7 +16,7 @@ spec:
   trafficDistribution: {{ .Values.nginx.service.trafficDistribution }}
   {{- end }}
   selector:
-    {{- include "nginx.selectorLabels" . | nindent 4 }}
+    {{- include "caching.nginx.selectorLabels" . | nindent 4 }}
   ports:
     - port: {{ .Values.nginx.service.port }}
       protocol: TCP

--- a/caching/templates/nginx-servicemonitor.yaml
+++ b/caching/templates/nginx-servicemonitor.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.nginx.name }}
   namespace: {{ .Values.prometheus.serviceMonitor.namespace | default .Values.namespace.name }}
   labels:
-    {{- include "nginx.labels" . | nindent 4 }}
+    {{- include "caching.nginx.labels" . | nindent 4 }}
     {{- with .Values.prometheus.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -16,7 +16,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "nginx.selectorLabels" . | nindent 6 }}
+      {{- include "caching.nginx.selectorLabels" . | nindent 6 }}
   namespaceSelector:
     matchNames:
       - {{ .Values.namespace.name }}

--- a/caching/templates/nginx-statefulset.yaml
+++ b/caching/templates/nginx-statefulset.yaml
@@ -5,21 +5,21 @@ metadata:
   name: {{ .Values.nginx.name }}
   namespace: {{ .Values.namespace.name }}
   labels:
-    {{- include "nginx.labels" . | nindent 4 }}
+    {{- include "caching.nginx.labels" . | nindent 4 }}
 spec:
   serviceName: {{ .Values.nginx.name }}-headless
   replicas: {{ .Values.nginx.replicaCount }}
   minReadySeconds: 30
   selector:
     matchLabels:
-      {{- include "nginx.selectorLabels" . | nindent 6 }}
+      {{- include "caching.nginx.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
         # Config checksum to trigger redeployment on config changes
         checksum/config: {{ include (print $.Template.BasePath "/nginx-configmap.yaml") . | sha256sum }}
       labels:
-        {{- include "nginx.selectorLabels" . | nindent 8 }}
+        {{- include "caching.nginx.selectorLabels" . | nindent 8 }}
     spec:
       topologySpreadConstraints:
         - maxSkew: 1
@@ -27,7 +27,7 @@ spec:
           whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
-              {{- include "nginx.selectorLabels" . | nindent 14 }}
+              {{- include "caching.nginx.selectorLabels" . | nindent 14 }}
       {{- if hasKey .Values.nginx "affinity" }}
       {{- with .Values.nginx.affinity }}
       affinity:
@@ -35,7 +35,7 @@ spec:
       {{- end }}
       {{- else }}
       affinity:
-        {{- include "nginx.defaultAffinity" . | nindent 8 }}
+        {{- include "caching.nginx.defaultAffinity" . | nindent 8 }}
       {{- end }}
       {{- with .Values.nginx.podSecurityContext }}
       securityContext:
@@ -135,7 +135,7 @@ spec:
               readOnly: true
         # Access-log-exporter sidecar: exposes Prometheus metrics from NGINX access logs
         - name: access-log-exporter
-          image: {{ include "nginx.exporter.image" . }}
+          image: {{ include "caching.nginx.exporter.image" . }}
           imagePullPolicy: IfNotPresent
           args:
             - "--config=/etc/exporter/config.yaml"

--- a/caching/templates/nginx-test-backend.yaml
+++ b/caching/templates/nginx-test-backend.yaml
@@ -23,7 +23,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: nginx-test-backend
-        image: {{ include "squid.test.image" . }}
+        image: {{ include "caching.test.image" . }}
         imagePullPolicy: IfNotPresent
         command: ["/app/nginx-test-backend"]
         {{- if .Values.nginx.auth.enabled }}

--- a/caching/templates/self-signed-cluster-issuer.yaml
+++ b/caching/templates/self-signed-cluster-issuer.yaml
@@ -4,7 +4,7 @@ kind: ClusterIssuer
 metadata:
   name: {{ .Values.namespace.name }}-self-signed-cluster-issuer
   labels:
-    {{- include "squid.labels" . | nindent 4 }}
+    {{- include "caching.squid.labels" . | nindent 4 }}
 spec:
   selfSigned: {}
 ---
@@ -14,7 +14,7 @@ metadata:
   name: {{ .Values.namespace.name }}-self-signed-ca
   namespace: {{ (index .Values "cert-manager").namespace }}
   labels:
-    {{- include "squid.labels" . | nindent 4 }}
+    {{- include "caching.squid.labels" . | nindent 4 }}
 spec:
   secretName: {{ .Values.namespace.name }}-root-ca-secret
   commonName: {{ .Values.namespace.name }}-self-signed-ca
@@ -32,7 +32,7 @@ kind: ClusterIssuer
 metadata:
   name: {{ .Values.namespace.name }}-ca-issuer
   labels:
-    {{- include "squid.labels" . | nindent 4 }}
+    {{- include "caching.squid.labels" . | nindent 4 }}
 spec:
   ca:
     secretName: {{ .Values.namespace.name }}-root-ca-secret

--- a/caching/templates/service.yaml
+++ b/caching/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.squid.name }}
   namespace: {{ .Values.namespace.name }}
   labels:
-    {{- include "squid.labels" . | nindent 4 }}
+    {{- include "caching.squid.labels" . | nindent 4 }}
   {{- if .Values.squidExporter.enabled }}
   annotations:
     prometheus.io/scrape: "true"
@@ -35,5 +35,5 @@ spec:
       name: per-site-http
     {{- end }}
   selector:
-    {{- include "squid.selectorLabels" . | nindent 4 }}
+    {{- include "caching.squid.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/caching/templates/serviceaccount.yaml
+++ b/caching/templates/serviceaccount.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "squid.serviceAccountName" . }}
+  name: {{ include "caching.squid.serviceAccountName" . }}
   namespace: {{ .Values.namespace.name }}
   labels:
-    {{- include "squid.labels" . | nindent 4 }}
+    {{- include "caching.squid.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/caching/templates/servicemonitor.yaml
+++ b/caching/templates/servicemonitor.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.squid.name }}
   namespace: {{ .Values.prometheus.serviceMonitor.namespace | default .Values.namespace.name }}
   labels:
-    {{- include "squid.labels" . | nindent 4 }}
+    {{- include "caching.squid.labels" . | nindent 4 }}
     {{- with .Values.prometheus.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
@@ -16,7 +16,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "squid.selectorLabels" . | nindent 6 }}
+      {{- include "caching.squid.selectorLabels" . | nindent 6 }}
   namespaceSelector:
     matchNames:
       - {{ .Values.namespace.name }}

--- a/caching/templates/test-pod.yaml
+++ b/caching/templates/test-pod.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/component: test
     app: {{ .Values.test.name }}
-    helm.sh/chart: {{ include "squid.chart" . }}
+    helm.sh/chart: {{ include "caching.chart" . }}
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-weight": "1"
@@ -23,7 +23,7 @@ spec:
   serviceAccountName: {{ .Values.squid.name }}-test
   containers:
   - name: ginkgo-test
-    image: "{{ include "squid.test.image" . }}"
+    image: "{{ include "caching.test.image" . }}"
     imagePullPolicy: {{ .Values.test.image.pullPolicy | default "IfNotPresent" }}
     workingDir: /app
     command:
@@ -47,7 +47,7 @@ spec:
     # Pass the test image to the test binary so it knows which image to preserve when calling
     # helm install/upgrade commands.
     - name: SQUID_TEST_IMAGE
-      value: "{{ include "squid.test.image" . }}"
+      value: "{{ include "caching.test.image" . }}"
     resources:
       {{- toYaml .Values.test.resources | nindent 6 }}
 {{- end }}

--- a/caching/templates/test-rbac.yaml
+++ b/caching/templates/test-rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ .Values.squid.name }}-test
   namespace: {{ .Values.namespace.name }}
   labels:
-    {{- include "squid.labels" . | nindent 4 }}
+    {{- include "caching.squid.labels" . | nindent 4 }}
     app.kubernetes.io/component: test
   {{- if not .Values.mirrord.enabled }}
   annotations:
@@ -20,7 +20,7 @@ kind: ClusterRole
 metadata:
   name: {{ .Values.squid.name }}-test
   labels:
-    {{- include "squid.labels" . | nindent 4 }}
+    {{- include "caching.squid.labels" . | nindent 4 }}
     app.kubernetes.io/component: test
   {{- if not .Values.mirrord.enabled }}
   annotations:
@@ -60,7 +60,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ .Values.squid.name }}-test
   labels:
-    {{- include "squid.labels" . | nindent 4 }}
+    {{- include "caching.squid.labels" . | nindent 4 }}
     app.kubernetes.io/component: test
   {{- if not .Values.mirrord.enabled }}
   annotations:

--- a/caching/templates/trust-manager-bundle.yaml
+++ b/caching/templates/trust-manager-bundle.yaml
@@ -4,7 +4,7 @@ kind: Bundle
 metadata:
   name: {{ .Values.namespace.name }}-ca-bundle
   labels:
-    {{- include "squid.labels" . | nindent 4 }}
+    {{- include "caching.squid.labels" . | nindent 4 }}
 spec:
   sources:
   - secret:

--- a/caching/values.schema.json
+++ b/caching/values.schema.json
@@ -529,7 +529,7 @@
               },
               "required": ["pullPolicy"],
               "additionalProperties": false,
-              "description": "Mirrord target pod image configuration (repository and tag are set dynamically by squid.test.image helper)"
+              "description": "Mirrord target pod image configuration (repository and tag are set dynamically by caching.test.image helper)"
             },
             "resources": {
               "$ref": "#/$defs/resources"

--- a/caching/values.yaml
+++ b/caching/values.yaml
@@ -557,7 +557,7 @@ mirrord:
     name: "mirrord-test-target" # Name of the mirrord target pod
     image:
       pullPolicy: IfNotPresent
-      # Note: repository and tag are set dynamically by squid.test.image helper in _helpers.tpl
+      # Note: repository and tag are set dynamically by caching.test.image helper in _helpers.tpl
     resources:
       requests:
         cpu: 50m


### PR DESCRIPTION
Rename all chart-level template definitions in _helpers.tpl to follow the caching.* naming pattern, reflecting the chart's new name. This includes chart-level helpers, Squid component helpers, and Nginx component helpers.

Selector label VALUES remain unchanged - they still output 'squid' and 'nginx' as these are runtime workload identifiers, not chart names.

Updated all template files to use the new helper names.

https://redhat.atlassian.net/browse/KFLUXVNGD-1052

Assisted-By: Claude Code

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [x] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
