### PR TITLE
fix(KFLUXVNGD-932): extend root CA lifetime to reduce rotation frequency

### DIFF
--- a/caching/templates/proxy-certificate.yaml
+++ b/caching/templates/proxy-certificate.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Values.namespace.name }}
 spec:
   isCA: true
+  duration: 2160h # 90 days
+  renewBefore: 360h # 15 days
   subject:
     organizations:
       - konflux

--- a/caching/templates/self-signed-cluster-issuer.yaml
+++ b/caching/templates/self-signed-cluster-issuer.yaml
@@ -18,10 +18,12 @@ metadata:
 spec:
   secretName: {{ .Values.namespace.name }}-root-ca-secret
   commonName: {{ .Values.namespace.name }}-self-signed-ca
+  duration: 43800h # 5 years
+  renewBefore: 2160h # 90 days
   isCA: true
   privateKey:
     algorithm: ECDSA
-    size: 256  
+    size: 256
   issuerRef:
     name: {{ .Values.namespace.name }}-self-signed-cluster-issuer
     kind: ClusterIssuer


### PR DESCRIPTION
The self-signed root CA was using cert-manager's default 90-day validity, which caused a trust chain breakage when the CA rotated with a new key pair. Clients saw "x509: ECDSA verification failure" because the leaf certificate was still signed by the old CA key while trust-manager had already distributed the new CA to tenant namespaces.

Extend the root CA to a 5-year duration (renewBefore: 90 days) to make rotation rare. The proxy leaf certificate retains the cert-manager default validity (duration: 90 days, renewBefore: 15 days), now set explicitly.

Tradeoff: when the CA does eventually rotate, cert-manager will generate a new key pair but will not automatically re-issue the leaf certificate. This requires manual intervention: deleting the leaf cert secret and restarting the squid pods so the leaf is re-issued against the new CA. trust-manager does not yet support keeping previous CA certs in the bundle to bridge the rotation gap, though this is being tracked upstream: https://github.com/cert-manager/trust-manager/issues/560

Assisted-by: Claude claude-opus-4-6

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [ ] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
