### PR TITLE
refactor(KFLUXVNGD-1054): update values.schema.json chart references

### DIFF
--- a/caching/values.schema.json
+++ b/caching/values.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema#",
   "$id": "https://github.com/konflux-ci/caching/caching/values.schema.json",
-  "title": "Squid Proxy Helm Chart Values Schema",
-  "description": "JSON Schema for validating values.yaml in the Squid Helm chart",
+  "title": "Caching Helm Chart Values Schema",
+  "description": "JSON Schema for validating values.yaml in the Caching Helm chart (Squid forward proxy + Nginx reverse proxy)",
   "type": "object",
 
   "properties": {


### PR DESCRIPTION
Update values.schema.json title and description to reference "Caching" chart instead of "Squid" to align with the chart rename.

Component-specific references (e.g., "Squid deployment", "Squid forward proxy component") are intentionally preserved as they refer to the Squid component, not the chart name.

Jira-Url: https://redhat.atlassian.net/browse/KFLUXVNGD-1054

Assisted-By: Claude Code

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [ ] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
