### PR TITLE
refactor(KFLUXVNGD-1055): update magefile.go for chart rename

### DIFF
--- a/.github/workflows/devcontainer-ci.yml
+++ b/.github/workflows/devcontainer-ci.yml
@@ -109,7 +109,7 @@ jobs:
     - name: Deploy Kind environment
       run: |
         # Build with coverage instrumentation and deploy to Kind
-        podman exec -e GOTOOLCHAIN=auto -e GOSUMDB=sum.golang.org -e ENABLE_COVERAGE=true -w /workspaces/caching devcontainer-test mage squidHelm:up
+        podman exec -e GOTOOLCHAIN=auto -e GOSUMDB=sum.golang.org -e ENABLE_COVERAGE=true -w /workspaces/caching devcontainer-test mage cachingHelm:up
 
     - name: Run our test suite (via mirrord)
       run: |

--- a/.tekton/squid-helm-pull-request.yaml
+++ b/.tekton/squid-helm-pull-request.yaml
@@ -206,7 +206,7 @@ spec:
                   "target": "quay.io/redhat-user-workloads/konflux-vanguard-tenant/caching/squid:on-pr-{{revision}}"
                 },
                 {
-                  "source": "localhost/konflux-ci/squid-test",
+                  "source": "localhost/konflux-ci/caching-tester",
                   "target": "quay.io/redhat-user-workloads/konflux-vanguard-tenant/caching/squid-tester:on-pr-{{revision}}"
                 },
                 {

--- a/.tekton/squid-helm-push.yaml
+++ b/.tekton/squid-helm-push.yaml
@@ -193,7 +193,7 @@ spec:
                   "target": "quay.io/redhat-user-workloads/konflux-vanguard-tenant/caching/squid:{{revision}}"
                 },
                 {
-                  "source": "localhost/konflux-ci/squid-test",
+                  "source": "localhost/konflux-ci/caching-tester",
                   "target": "quay.io/redhat-user-workloads/konflux-vanguard-tenant/caching/squid-tester:{{revision}}"
                 },
                 {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -26,7 +26,7 @@
             "command": "bash",
             "args": [
                 "-c",
-                "mage kind:status && mage squidHelm:status"
+                "mage kind:status && mage cachingHelm:status"
             ],
             "group": "build",
             "presentation": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ mage -l                     # List all targets
 mage all                    # Full setup: cluster + build + deploy + test
 mage test:unit              # Unit tests (no cluster needed)
 mage test:cluster           # E2E tests (requires kind + mirrord)
-mage squidHelm:up           # Deploy/upgrade Helm chart
+mage cachingHelm:up         # Deploy/upgrade Helm chart
 mage build:squid            # Build squid container image
 mage lint:go                # golangci-lint (see Linting below)
 ```

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ This single command creates a Kind cluster, builds images, deploys the Helm char
 | `mage kind:down` | Delete Kind cluster |
 | `mage build:squid` | Build Squid image |
 | `mage build:loadSquid` | Load image into cluster |
-| `mage squidHelm:up` | Deploy Helm chart |
-| `mage squidHelm:status` | Check deployment |
+| `mage cachingHelm:up` | Deploy Helm chart |
+| `mage cachingHelm:status` | Check deployment |
 | `mage test:unit` | Unit tests (no cluster) |
 | `mage test:cluster` | E2E tests with mirrord |
 
@@ -163,7 +163,7 @@ For detailed configuration, see [docs/monitoring.md](docs/monitoring.md).
 ```bash
 kubectl get pods -n caching
 kubectl logs -n caching -l app.kubernetes.io/name=squid -c squid
-mage squidHelm:status
+mage cachingHelm:status
 ```
 
 ### Common Issues

--- a/caching/values.yaml
+++ b/caching/values.yaml
@@ -28,7 +28,7 @@ envSettings:
         tag: "latest"
     test:
       image:
-        repository: localhost/konflux-ci/squid-test
+        repository: localhost/konflux-ci/caching-tester
         tag: "latest"
     nginx:
       exporter:

--- a/docs/development.md
+++ b/docs/development.md
@@ -84,7 +84,7 @@ mage all
 mage kind:up           # Create cluster
 mage build:squid       # Build image
 mage build:loadSquid   # Load into cluster
-mage squidHelm:up      # Deploy chart
+mage cachingHelm:up    # Deploy chart
 mage test:cluster      # Run e2e tests
 ```
 
@@ -123,10 +123,10 @@ Run `mage -l` for the full list. Key commands:
 | `mage build:accessLogExporter` | Build access-log-exporter image (for use as sidecar with nginx) |
 | `mage build:loadAccessLogExporter` | Load access-log-exporter into cluster |
 | **Deployment** | |
-| `mage squidHelm:up` | Deploy/upgrade helm chart |
-| `mage squidHelm:down` | Remove deployment |
-| `mage squidHelm:status` | Check deployment status |
-| `mage squidHelm:upClean` | Force redeploy |
+| `mage cachingHelm:up` | Deploy/upgrade helm chart |
+| `mage cachingHelm:down` | Remove deployment |
+| `mage cachingHelm:status` | Check deployment status |
+| `mage cachingHelm:upClean` | Force redeploy |
 | **Testing** | |
 | `mage test:unit` | Run unit tests (no cluster) |
 | `mage test:cluster` | Run E2E tests with mirrord |
@@ -180,8 +180,8 @@ podman build --target access-log-exporter -t localhost/konflux-ci/access-log-exp
 kind load image-archive --name caching <(podman save localhost/konflux-ci/access-log-exporter:latest)
 
 # Build test image
-podman build -t localhost/konflux-ci/squid-test:latest -f test.Containerfile .
-kind load image-archive --name caching <(podman save localhost/konflux-ci/squid-test:latest)
+podman build -t localhost/konflux-ci/caching-tester:latest -f test.Containerfile .
+kind load image-archive --name caching <(podman save localhost/konflux-ci/caching-tester:latest)
 ```
 
 ### 3. Deploy with Helm
@@ -234,7 +234,7 @@ kind delete cluster --name caching
 # Remove local images (optional)
 podman rmi localhost/konflux-ci/squid:latest
 podman rmi localhost/konflux-ci/access-log-exporter:latest
-podman rmi localhost/konflux-ci/squid-test:latest
+podman rmi localhost/konflux-ci/caching-tester:latest
 ```
 
 > **Note**: `mage clean` handles most cleanup automatically. Manual image removal is only needed if you want to reclaim disk space.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -30,7 +30,7 @@ For local development and debugging, use mirrord to run tests with cluster netwo
 
 ```bash
 # Setup test environment first
-mage squidHelm:up
+mage cachingHelm:up
 
 # Run tests with cluster network access
 mage test:cluster
@@ -80,7 +80,7 @@ Available via Ctrl+Shift+P → "Tasks: Run Task":
 | Run Ginkgo Tests (Current Directory) | Run tests in the currently open directory |
 | Run Ginkgo Tests with Coverage | Generate test coverage reports |
 | Run Focused Ginkgo Tests | Run specific test patterns |
-| Check Test Environment Status | Run `mage kind:status && mage squidHelm:status` |
+| Check Test Environment Status | Run `mage kind:status && mage cachingHelm:status` |
 | Generate Ginkgo Test File | Bootstrap a new Ginkgo test file |
 | Clean Test Environment | Clean up all resources |
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -137,7 +137,7 @@ which mirrord
 mage test:cluster  # Check output for detailed error messages
 
 # Verify cluster state before running tests
-mage squidHelm:status
+mage cachingHelm:status
 
 # Check if all pods are running
 kubectl get pods -n caching

--- a/magefile.go
+++ b/magefile.go
@@ -19,8 +19,8 @@ type Kind mg.Namespace
 // Build manages image building operations
 type Build mg.Namespace
 
-// SquidHelm manages squid helm chart operations
-type SquidHelm mg.Namespace
+// CachingHelm manages caching helm chart operations
+type CachingHelm mg.Namespace
 
 // Test manages test execution operations
 type Test mg.Namespace
@@ -37,7 +37,7 @@ const (
 	// SquidContainerfile is the path to the Containerfile for squid
 	squidContainerfile = "Containerfile"
 	// TestImageTag is the tag used for the test container image
-	testImageTag = "localhost/konflux-ci/squid-test:latest"
+	testImageTag = "localhost/konflux-ci/caching-tester:latest"
 	// TestContainerfile is the path to the Containerfile for tests
 	testContainerfile = "test.Containerfile"
 	chartPath         = "./caching"
@@ -429,12 +429,12 @@ func (Build) LoadTestImage() error {
 	return nil
 }
 
-// SquidHelm:Up deploys the Squid Helm chart to the cluster
-func (SquidHelm) Up() error {
+// CachingHelm:Up deploys the caching Helm chart to the cluster
+func (CachingHelm) Up() error {
 	// Ensure dependencies are met (squid, test, and access-log-exporter images needed)
 	mg.Deps(Build.LoadSquid, Build.LoadTestImage, Build.LoadAccessLogExporter)
 
-	fmt.Println("⚓ Deploying Squid Helm chart...")
+	fmt.Println("⚓ Deploying caching Helm chart...")
 
 	// Ensure required helm repositories are available
 	fmt.Printf("📦 Ensuring helm repositories are available...\n")
@@ -450,7 +450,7 @@ func (SquidHelm) Up() error {
 		return fmt.Errorf("failed to build helm dependencies: %w", err)
 	}
 
-	fmt.Printf("⚓ Installing/upgrading squid helm chart and waiting for readiness...\n")
+	fmt.Printf("⚓ Installing/upgrading caching helm chart (release: squid) and waiting for readiness...\n")
 	err = sh.Run(
 		"helm",
 		"upgrade",
@@ -470,18 +470,18 @@ func (SquidHelm) Up() error {
 
 	// Show comprehensive deployment status
 	fmt.Printf("🔍 Verifying deployment status...\n")
-	err = (SquidHelm{}).Status()
+	err = (CachingHelm{}).Status()
 	if err != nil {
 		return fmt.Errorf("deployment verification failed: %w", err)
 	}
 
-	fmt.Printf("✅ Squid helm chart deployed successfully!\n")
+	fmt.Printf("✅ Caching helm chart deployed successfully!\n")
 	return nil
 }
 
-// SquidHelm:Down removes the Squid Helm chart from the cluster
-func (SquidHelm) Down() error {
-	fmt.Println("🗑️  Removing Squid Helm chart...")
+// CachingHelm:Down removes the caching Helm chart from the cluster
+func (CachingHelm) Down() error {
+	fmt.Println("🗑️  Removing caching Helm chart...")
 
 	// Check if release exists first
 	exists, err := internal.ReleaseExists("squid")
@@ -495,7 +495,7 @@ func (SquidHelm) Down() error {
 	}
 
 	// Uninstall the helm release
-	fmt.Printf("🗑️  Uninstalling squid helm release...\n")
+	fmt.Printf("🗑️  Uninstalling caching helm release (squid)...\n")
 	err = sh.Run("helm", "uninstall", "squid")
 	if err != nil {
 		return fmt.Errorf("failed to uninstall helm chart: %w", err)
@@ -508,27 +508,27 @@ func (SquidHelm) Down() error {
 		// Don't fail the function, just warn - the namespace might be stuck
 	}
 
-	fmt.Printf("✅ Squid helm chart removed successfully!\n")
+	fmt.Printf("✅ Caching helm chart removed successfully!\n")
 	return nil
 }
 
-// SquidHelm:UpClean forces redeployment of the Squid Helm chart (removes and reinstalls)
-func (SquidHelm) UpClean() error {
-	fmt.Println("🔄 Force redeploying Squid Helm chart...")
+// CachingHelm:UpClean forces redeployment of the caching Helm chart (removes and reinstalls)
+func (CachingHelm) UpClean() error {
+	fmt.Println("🔄 Force redeploying caching Helm chart...")
 
 	// Remove existing release
-	err := (SquidHelm{}).Down()
+	err := (CachingHelm{}).Down()
 	if err != nil {
 		return fmt.Errorf("failed to remove existing release: %w", err)
 	}
 
 	// Install fresh release
-	fmt.Printf("⚓ Installing fresh squid helm chart...\n")
-	return (SquidHelm{}).Up()
+	fmt.Printf("⚓ Installing fresh caching helm chart...\n")
+	return (CachingHelm{}).Up()
 }
 
-// SquidHelm:Status shows the deployment status
-func (SquidHelm) Status() error {
+// CachingHelm:Status shows the deployment status
+func (CachingHelm) Status() error {
 	fmt.Println("📊 Checking deployment status...")
 
 	// Check if squid helm release exists
@@ -595,9 +595,9 @@ func All() error {
 	// Run unit tests first for fast feedback
 	mg.Deps(Test.Unit)
 
-	// SquidHelm.Up will automatically handle all dependencies:
-	// SquidHelm.Up -> Build.LoadSquid + Build.LoadSquidExporter + Build.LoadTestImage -> Kind.Up + Build.Squid + Build.TestImage
-	err := (SquidHelm{}).Up()
+	// CachingHelm.Up will automatically handle all dependencies:
+	// CachingHelm.Up -> Build.LoadSquid + Build.LoadAccessLogExporter + Build.LoadTestImage -> Kind.Up + Build.Squid + Build.TestImage
+	err := (CachingHelm{}).Up()
 	if err != nil {
 		return err
 	}
@@ -621,7 +621,7 @@ func All() error {
 	}
 	fmt.Println("✅ All helm tests passed!")
 	// Reset squid helm chart to values.yaml defaults after tests complete
-	resetSquidToDefaults()
+	resetCachingToDefaults()
 	fmt.Println()
 	fmt.Println("🎉 Complete automation workflow finished successfully!")
 	fmt.Println("Your local dev/test environment is ready:")
@@ -710,11 +710,11 @@ func runClusterTests(replicaCount int) error {
 		"./tests/e2e/e2e.test", "-ginkgo.v", "-ginkgo.label-filter="+os.Getenv("GINKGO_LABEL_FILTER"))
 }
 
-// resetSquidToDefaults resets the squid helm release to values.yaml defaults
+// resetCachingToDefaults resets the caching helm release to values.yaml defaults
 // Uses environment=dev and preserves GINKGO_LABEL_FILTER if set
 // Errors are logged as warnings but don't cause the function to fail
-func resetSquidToDefaults() {
-	fmt.Println("🔄 Resetting squid to values.yaml defaults...")
+func resetCachingToDefaults() {
+	fmt.Println("🔄 Resetting caching chart to values.yaml defaults...")
 	err := sh.Run(
 		"helm",
 		"upgrade",
@@ -727,21 +727,21 @@ func resetSquidToDefaults() {
 		"--timeout=300s",
 	)
 	if err != nil {
-		fmt.Printf("⚠️  Warning: Failed to reset squid to values.yaml defaults: %v\n", err)
+		fmt.Printf("⚠️  Warning: Failed to reset caching chart to values.yaml defaults: %v\n", err)
 	}
 }
 
 // Test:Cluster runs tests with cluster network access via mirrord
 func (Test) Cluster() error {
 	// Ensure cluster and deployment are ready (includes mirrord infrastructure)
-	mg.Deps(SquidHelm{}.Up)
+	mg.Deps(CachingHelm{}.Up)
 
 	// Run with default replica count (0 = use values.yaml default)
 	err := runClusterTests(0)
 	if err != nil {
 		return fmt.Errorf("failed to run tests: %w", err)
 	}
-	resetSquidToDefaults()
+	resetCachingToDefaults()
 	return nil
 }
 
@@ -753,7 +753,7 @@ func (Test) ClusterMultiReplica() error {
 	os.Setenv("SQUID_REPLICA_COUNT", "3")
 
 	// Ensure cluster and deployment are ready
-	mg.Deps(SquidHelm{}.Up)
+	mg.Deps(CachingHelm{}.Up)
 
 	fmt.Println("🧪 Upgrading deployment to 3 replicas...")
 
@@ -783,6 +783,6 @@ func (Test) ClusterMultiReplica() error {
 	if err != nil {
 		return fmt.Errorf("failed to run tests: %w", err)
 	}
-	resetSquidToDefaults()
+	resetCachingToDefaults()
 	return nil
 }


### PR DESCRIPTION
Rename SquidHelm namespace to CachingHelm and update all references to align with the chart directory rename from squid/ to caching/.

Helm release name stays "squid" to avoid resource collisions.

Jira-Url: https://redhat.atlassian.net/browse/KFLUXVNGD-1055

Assisted-By: Claude Code

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [ ] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
