### PR TITLE
feat(KFLUXVNGD-1060): add caching-helm Konflux component

### DIFF
--- a/.tekton/caching-helm-pull-request.yaml
+++ b/.tekton/caching-helm-pull-request.yaml
@@ -1,0 +1,326 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/konflux-ci/caching?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: "{{revision}}"
+    build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
+    build.appstudio.redhat.com/target_branch: "{{target_branch}}"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" && target_branch == "main" ||
+      event == "push" && target_branch.startsWith("gh-readonly-queue/main/")
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: caching
+    appstudio.openshift.io/component: caching-helm
+    pipelines.appstudio.openshift.io/type: build
+    release.appstudio.openshift.io/auto-release: "false"
+  name: caching-helm-on-pull-request
+  namespace: konflux-vanguard-tenant
+spec:
+  params:
+    - name: git-url
+      value: "{{source_url}}"
+    - name: revision
+      value: "{{revision}}"
+    - name: output-image
+      value: quay.io/redhat-user-workloads/konflux-vanguard-tenant/caching/caching-helm:on-pr-{{revision}}
+    - name: image-expires-after
+      value: 5d
+    - name: dockerfile
+      value: helm.Containerfile
+    - name: path-context
+      value: "caching"
+    - name: hermetic
+      value: "false"
+  pipelineSpec:
+    description: |
+      This pipeline is ideal for building Helm charts while maintaining trust after pipeline customization.
+    params:
+      - description: Source Repository URL
+        name: git-url
+        type: string
+      - default: ""
+        description: Revision of the Source Repository
+        name: revision
+        type: string
+      - description: Fully Qualified Output Image
+        name: output-image
+        type: string
+      - default: .
+        description:
+          Path to the source code of an application's component from where
+          to build image.
+        name: path-context
+        type: string
+      - default: Dockerfile
+        description:
+          Path to the Dockerfile inside the context specified by parameter
+          path-context
+        name: dockerfile
+        type: string
+      - default: "false"
+        description: Skip checks against built image
+        name: skip-checks
+        type: string
+      - default: "false"
+        description: Execute the build with network isolation
+        name: hermetic
+        type: string
+      - default: ""
+        description: Build dependencies to be prefetched by Cachi2
+        name: prefetch-input
+        type: string
+      - default: ""
+        description:
+          Image tag expiration time, time values could be something like
+          1h, 2d, 3w for hours, days, and weeks, respectively.
+        name: image-expires-after
+        type: string
+      - default: "false"
+        description: Build a source image.
+        name: build-source-image
+        type: string
+      - default: []
+        description: Array of --build-arg values ("arg=value" strings) for buildah
+        name: build-args
+        type: array
+      - default: ""
+        description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+        name: build-args-file
+        type: string
+      - default: "false"
+        description:
+          Whether to enable privileged mode, should be used only with remote
+          VMs
+        name: privileged-nested
+        type: string
+      - name: enable-cache-proxy
+        default: 'false'
+        description: Enable cache proxy configuration
+        type: string
+      - name: enable-package-registry-proxy
+        default: 'true'
+        description: Use the package registry proxy when prefetching dependencies
+        type: string
+      - name: sast-target-dirs
+        type: string
+        default: .
+        description: Target directories to scan with SAST tools. Multiple values should be separated with commas.
+    results:
+      - description: ""
+        name: IMAGE_URL
+        value: $(tasks.build-helm-chart.results.IMAGE_URL)
+      - description: ""
+        name: IMAGE_DIGEST
+        value: $(tasks.build-helm-chart.results.IMAGE_DIGEST)
+      - description: ""
+        name: CHAINS-GIT_URL
+        value: $(tasks.clone-repository.results.url)
+      - description: ""
+        name: CHAINS-GIT_COMMIT
+        value: $(tasks.clone-repository.results.commit)
+    tasks:
+      - name: init
+        params:
+          - name: enable-cache-proxy
+            value: $(params.enable-cache-proxy)
+        taskRef:
+          params:
+            - name: name
+              value: init
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08
+            - name: kind
+              value: task
+          resolver: bundles
+      - name: clone-repository
+        params:
+          - name: url
+            value: $(params.git-url)
+          - name: revision
+            value: $(params.revision)
+          - name: ociStorage
+            value: $(params.output-image).git
+          - name: ociArtifactExpiresAfter
+            value: $(params.image-expires-after)
+        runAfter:
+          - init
+        taskRef:
+          params:
+            - name: name
+              value: git-clone-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:d30f13dd15daf89dd6dc645243b3444d35570d13f7840c3fd65e366022515205
+            - name: kind
+              value: task
+          resolver: bundles
+        workspaces:
+          - name: basic-auth
+            workspace: git-auth
+      - name: prefetch-dependencies
+        params:
+          - name: input
+            value: $(params.prefetch-input)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+          - name: ociStorage
+            value: $(params.output-image).prefetch
+          - name: ociArtifactExpiresAfter
+            value: $(params.image-expires-after)
+          - name: enable-package-registry-proxy
+            value: $(params.enable-package-registry-proxy)
+        runAfter:
+          - clone-repository
+        taskRef:
+          params:
+            - name: name
+              value: prefetch-dependencies-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:7e84b01526b6a50b920c0f456c8d95d6c5c2f7b81109ea772e1dcf7aba14bfa5
+            - name: kind
+              value: task
+          resolver: bundles
+        workspaces:
+          - name: git-basic-auth
+            workspace: git-auth
+          - name: netrc
+            workspace: netrc
+      - name: build-helm-chart
+        params:
+          - name: IMAGE
+            value: $(params.output-image)
+          - name: CHART_CONTEXT
+            value: $(params.path-context)
+          - name: COMMIT_SHA
+            value: $(tasks.clone-repository.results.commit)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+          - name: IMAGE_MAPPINGS
+            value: |
+              [
+                {
+                  "source": "localhost/konflux-ci/squid",
+                  "target": "quay.io/redhat-user-workloads/konflux-vanguard-tenant/caching/squid:on-pr-{{revision}}"
+                },
+                {
+                  "source": "localhost/konflux-ci/caching-tester",
+                  "target": "quay.io/redhat-user-workloads/konflux-vanguard-tenant/caching/squid-tester:on-pr-{{revision}}"
+                },
+                {
+                  "source": "localhost/konflux-ci/access-log-exporter",
+                  "target": "quay.io/redhat-user-workloads/konflux-vanguard-tenant/caching/access-log-exporter:on-pr-{{revision}}"
+                }
+              ]
+          - name: VERSION_SUFFIX
+            value: "-on-pr"
+          - name: VALUES_FILES
+            value:
+              - "values.yaml"
+        runAfter:
+          - prefetch-dependencies
+        taskRef:
+          params:
+            - name: name
+              value: build-helm-chart-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-build-helm-chart-oci-ta:0.3@sha256:da8946625604bb4851466cbb163df69f4f9cd973845dfb042cf1c80cecb84bac
+            - name: kind
+              value: task
+          resolver: bundles
+      - name: build-source-image
+        params:
+          - name: BINARY_IMAGE
+            value: $(tasks.build-helm-chart.results.IMAGE_URL)
+          - name: BINARY_IMAGE_DIGEST
+            value: $(tasks.build-helm-chart.results.IMAGE_DIGEST)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+          - name: CACHI2_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+        runAfter:
+          - build-helm-chart
+        taskRef:
+          params:
+            - name: name
+              value: source-build-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:8567bb7bf8fa9147c96b297533336fa7079ecf972cb86c09ccdd6bddedb25711
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(params.build-source-image)
+            operator: in
+            values:
+              - "true"
+      - name: sast-shell-check
+        params:
+        - name: image-digest
+          value: $(tasks.build-helm-chart.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-helm-chart.results.IMAGE_URL)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+        - name: TARGET_DIRS
+          value: $(params.sast-target-dirs)
+        runAfter:
+        - build-helm-chart
+        taskRef:
+          params:
+          - name: name
+            value: sast-shell-check-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:e5319fccebd21a1b06eb8fa6a46b78d745ce87464ed2cdd08b5f68a4489e2f14
+          - name: kind
+            value: task
+          resolver: bundles
+        when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+          - "false"
+      - name: sast-unicode-check
+        params:
+        - name: image-digest
+          value: $(tasks.build-helm-chart.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-helm-chart.results.IMAGE_URL)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+        - name: TARGET_DIRS
+          value: $(params.sast-target-dirs)
+        runAfter:
+        - build-helm-chart
+        taskRef:
+          params:
+          - name: name
+            value: sast-unicode-check-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:99cc3729af9c3e1e6821e07e4d46cc0366a43d53cfba42846c0461abb68b5362
+          - name: kind
+            value: task
+          resolver: bundles
+        when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+          - "false"
+    workspaces:
+      - name: git-auth
+        optional: true
+      - name: netrc
+        optional: true
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-caching-helm
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: "{{ git_auth_secret }}"
+status: {}

--- a/.tekton/caching-helm-push.yaml
+++ b/.tekton/caching-helm-push.yaml
@@ -1,0 +1,325 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/konflux-ci/caching?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: "{{revision}}"
+    build.appstudio.redhat.com/target_branch: "{{target_branch}}"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: caching
+    appstudio.openshift.io/component: caching-helm
+    pipelines.appstudio.openshift.io/type: build
+  name: caching-helm-on-push
+  namespace: konflux-vanguard-tenant
+spec:
+  params:
+    - name: git-url
+      value: "{{source_url}}"
+    - name: revision
+      value: "{{revision}}"
+    - name: output-image
+      value: quay.io/redhat-user-workloads/konflux-vanguard-tenant/caching/caching-helm:{{revision}}
+    - name: dockerfile
+      value: helm.Containerfile
+    - name: path-context
+      value: "caching"
+    - name: hermetic
+      value: "false"
+  pipelineSpec:
+    description: |
+      This pipeline is ideal for building Helm charts while maintaining trust after pipeline customization.
+    params:
+      - description: Source Repository URL
+        name: git-url
+        type: string
+      - default: ""
+        description: Revision of the Source Repository
+        name: revision
+        type: string
+      - description: Fully Qualified Output Image
+        name: output-image
+        type: string
+      - default: .
+        description:
+          Path to the source code of an application's component from where
+          to build image.
+        name: path-context
+        type: string
+      - default: Dockerfile
+        description:
+          Path to the Dockerfile inside the context specified by parameter
+          path-context
+        name: dockerfile
+        type: string
+      - default: "false"
+        description: Skip checks against built image
+        name: skip-checks
+        type: string
+      - default: "false"
+        description: Execute the build with network isolation
+        name: hermetic
+        type: string
+      - default: ""
+        description: Build dependencies to be prefetched by Cachi2
+        name: prefetch-input
+        type: string
+      - default: ""
+        description:
+          Image tag expiration time, time values could be something like
+          1h, 2d, 3w for hours, days, and weeks, respectively.
+        name: image-expires-after
+        type: string
+      - default: "false"
+        description: Build a source image.
+        name: build-source-image
+        type: string
+      - default: []
+        description: Array of --build-arg values ("arg=value" strings) for buildah
+        name: build-args
+        type: array
+      - default: ""
+        description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+        name: build-args-file
+        type: string
+      - default: "false"
+        description:
+          Whether to enable privileged mode, should be used only with remote
+          VMs
+        name: privileged-nested
+        type: string
+      - name: enable-package-registry-proxy
+        default: 'true'
+        description: Use the package registry proxy when prefetching dependencies
+        type: string
+      - name: sast-target-dirs
+        type: string
+        default: .
+        description: Target directories to scan with SAST tools. Multiple values should be separated with commas.
+    results:
+      - description: ""
+        name: IMAGE_URL
+        value: $(tasks.build-helm-chart.results.IMAGE_URL)
+      - description: ""
+        name: IMAGE_DIGEST
+        value: $(tasks.build-helm-chart.results.IMAGE_DIGEST)
+      - description: ""
+        name: CHAINS-GIT_URL
+        value: $(tasks.clone-repository.results.url)
+      - description: ""
+        name: CHAINS-GIT_COMMIT
+        value: $(tasks.clone-repository.results.commit)
+    tasks:
+      - name: init
+        taskRef:
+          params:
+            - name: name
+              value: init
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08
+            - name: kind
+              value: task
+          resolver: bundles
+      - name: clone-repository
+        params:
+          - name: url
+            value: $(params.git-url)
+          - name: revision
+            value: $(params.revision)
+          - name: ociStorage
+            value: $(params.output-image).git
+          - name: ociArtifactExpiresAfter
+            value: $(params.image-expires-after)
+        runAfter:
+          - init
+        taskRef:
+          params:
+            - name: name
+              value: git-clone-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:d30f13dd15daf89dd6dc645243b3444d35570d13f7840c3fd65e366022515205
+            - name: kind
+              value: task
+          resolver: bundles
+        workspaces:
+          - name: basic-auth
+            workspace: git-auth
+      - name: prefetch-dependencies
+        params:
+          - name: input
+            value: $(params.prefetch-input)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+          - name: ociStorage
+            value: $(params.output-image).prefetch
+          - name: ociArtifactExpiresAfter
+            value: $(params.image-expires-after)
+          - name: enable-package-registry-proxy
+            value: $(params.enable-package-registry-proxy)
+        runAfter:
+          - clone-repository
+        taskRef:
+          params:
+            - name: name
+              value: prefetch-dependencies-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:7e84b01526b6a50b920c0f456c8d95d6c5c2f7b81109ea772e1dcf7aba14bfa5
+            - name: kind
+              value: task
+          resolver: bundles
+        workspaces:
+          - name: git-basic-auth
+            workspace: git-auth
+          - name: netrc
+            workspace: netrc
+      - name: build-helm-chart
+        params:
+          - name: IMAGE
+            value: $(params.output-image)
+          - name: CHART_CONTEXT
+            value: $(params.path-context)
+          - name: COMMIT_SHA
+            value: $(tasks.clone-repository.results.commit)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+          - name: IMAGE_MAPPINGS
+            value: |
+              [
+                {
+                  "source": "localhost/konflux-ci/squid",
+                  "target": "quay.io/redhat-user-workloads/konflux-vanguard-tenant/caching/squid:{{revision}}"
+                },
+                {
+                  "source": "localhost/konflux-ci/caching-tester",
+                  "target": "quay.io/redhat-user-workloads/konflux-vanguard-tenant/caching/squid-tester:{{revision}}"
+                },
+                {
+                  "source": "localhost/konflux-ci/access-log-exporter",
+                  "target": "quay.io/redhat-user-workloads/konflux-vanguard-tenant/caching/access-log-exporter:{{revision}}"
+                },
+                {
+                  "source": "quay.io/konflux-ci/caching/squid",
+                  "target": "quay.io/konflux-ci/caching/squid:{{revision}}"
+                },
+                {
+                  "source": "quay.io/konflux-ci/caching/squid-test",
+                  "target": "quay.io/konflux-ci/caching/squid-test:{{revision}}"
+                },
+                {
+                  "source": "quay.io/konflux-ci/caching/access-log-exporter",
+                  "target": "quay.io/konflux-ci/caching/access-log-exporter:{{revision}}"
+                }
+              ]
+          - name: VERSION_SUFFIX
+            value: ""
+          - name: VALUES_FILES
+            value:
+              - "values.yaml"
+        runAfter:
+          - prefetch-dependencies
+        taskRef:
+          params:
+            - name: name
+              value: build-helm-chart-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-build-helm-chart-oci-ta:0.3@sha256:da8946625604bb4851466cbb163df69f4f9cd973845dfb042cf1c80cecb84bac
+            - name: kind
+              value: task
+          resolver: bundles
+      - name: build-source-image
+        params:
+          - name: BINARY_IMAGE
+            value: $(tasks.build-helm-chart.results.IMAGE_URL)
+          - name: BINARY_IMAGE_DIGEST
+            value: $(tasks.build-helm-chart.results.IMAGE_DIGEST)
+          - name: SOURCE_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+          - name: CACHI2_ARTIFACT
+            value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+        runAfter:
+          - build-helm-chart
+        taskRef:
+          params:
+            - name: name
+              value: source-build-oci-ta
+            - name: bundle
+              value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:8567bb7bf8fa9147c96b297533336fa7079ecf972cb86c09ccdd6bddedb25711
+            - name: kind
+              value: task
+          resolver: bundles
+        when:
+          - input: $(params.build-source-image)
+            operator: in
+            values:
+              - "true"
+      - name: sast-shell-check
+        params:
+        - name: image-digest
+          value: $(tasks.build-helm-chart.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-helm-chart.results.IMAGE_URL)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+        - name: TARGET_DIRS
+          value: $(params.sast-target-dirs)
+        runAfter:
+        - build-helm-chart
+        taskRef:
+          params:
+          - name: name
+            value: sast-shell-check-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:e5319fccebd21a1b06eb8fa6a46b78d745ce87464ed2cdd08b5f68a4489e2f14
+          - name: kind
+            value: task
+          resolver: bundles
+        when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+          - "false"
+      - name: sast-unicode-check
+        params:
+        - name: image-digest
+          value: $(tasks.build-helm-chart.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-helm-chart.results.IMAGE_URL)
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+        - name: TARGET_DIRS
+          value: $(params.sast-target-dirs)
+        runAfter:
+        - build-helm-chart
+        taskRef:
+          params:
+          - name: name
+            value: sast-unicode-check-oci-ta
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:99cc3729af9c3e1e6821e07e4d46cc0366a43d53cfba42846c0461abb68b5362
+          - name: kind
+            value: task
+          resolver: bundles
+        when:
+        - input: $(params.skip-checks)
+          operator: in
+          values:
+          - "false"
+    workspaces:
+      - name: git-auth
+        optional: true
+      - name: netrc
+        optional: true
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-caching-helm
+  workspaces:
+    - name: git-auth
+      secret:
+        secretName: "{{ git_auth_secret }}"
+status: {}


### PR DESCRIPTION
Add new pipeline files for caching-helm component that builds from the caching/ directory. This creates a new component alongside the existing squid-helm component to support the Helm chart rename transition.

Jira-Url: https://redhat.atlassian.net/browse/KFLUXVNGD-1060
Assisted-By: Claude Code

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
