### PR TITLE
feat(KFLUXVNGD-1062): add caching-e2e-eaas-test pipeline for caching-tester

### DIFF
--- a/.tekton/caching-e2e-eaas-test.yaml
+++ b/.tekton/caching-e2e-eaas-test.yaml
@@ -1,0 +1,434 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/konflux-ci/caching?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+  labels:
+    appstudio.openshift.io/application: caching
+    appstudio.openshift.io/component: caching-tester
+    pipelines.appstudio.openshift.io/type: test
+  name: caching-e2e-eaas-test
+  namespace: konflux-vanguard-tenant
+spec:
+  params:
+    - name: test-name
+      value: caching-openshift-e2e
+    - name: ocp-version
+      value: "4.17"
+    - name: test-event-type
+      value: pull_request
+    - name: machine-type
+      value: m5.xlarge
+
+  pipelineSpec:
+    description: |-
+      This pipeline automates the process of running end-to-end tests for Caching
+      on an ephemeral OpenShift cluster using EaaS (Environment as a Service).
+      It runs on pull_request events and uses PR build images directly.
+    params:
+      - name: SNAPSHOT
+        description: 'JSON string containing the application components and their container images'
+        default: '{"components": []}'
+        type: string
+      - name: test-name
+        description: 'The name of the test corresponding to a defined Konflux integration test.'
+        default: 'caching-e2e'
+      - name: ocp-version
+        description: 'The OpenShift version to use for the ephemeral cluster deployment.'
+        type: string
+        default: "4.17"
+      - name: test-event-type
+        description: 'Indicates if the test is triggered by a Pull Request or Push event.'
+        default: 'pull_request'
+      - name: machine-type
+        description: 'The EC2 instance type for cluster worker nodes (amd64 or arm64).'
+        type: string
+        default: "m5.xlarge"
+      - name: helm-version
+        description: 'The Helm version to install and use for deployments.'
+        type: string
+        default: "3.21.2"
+    tasks:
+      - name: test-metadata
+        taskRef:
+          resolver: git
+          params:
+            - name: url
+              value: https://github.com/konflux-ci/tekton-integration-catalog.git
+            - name: revision
+              value: main
+            - name: pathInRepo
+              value: tasks/test-metadata/0.4/test-metadata.yaml
+        params:
+          - name: SNAPSHOT
+            value: $(params.SNAPSHOT)
+          - name: test-name
+            value: $(context.pipelineRun.name)
+
+      # Extract component images from the snapshot
+      # The snapshot contains all built component images for this PR
+      - name: extract-snapshot-images
+        runAfter:
+          - test-metadata
+        taskSpec:
+          params:
+            - name: SNAPSHOT
+              type: string
+          results:
+            - name: squid-image
+              description: Container image for the squid component
+            - name: caching-tester-image
+              description: Container image for the caching-tester component
+          steps:
+            - name: extract
+              image: quay.io/konflux-ci/konflux-test:v1.5.2@sha256:c370a7bc6e172cdbab001f1a19f37ebc95f47c3d8fe2d915fa4641132490ead7
+              script: |
+                #!/bin/bash
+                set -euo pipefail
+
+                echo "Extracting component images from snapshot..."
+                snapshot='$(params.SNAPSHOT)'
+                echo "Snapshot: $snapshot"
+
+                # Extract squid image
+                squid_image=$(echo "$snapshot" | jq -r '.components[] | select(.name == "squid") | .containerImage')
+                if [ -z "$squid_image" ] || [ "$squid_image" = "null" ]; then
+                  echo "ERROR: Could not find squid component in snapshot"
+                  exit 1
+                fi
+                echo "Squid image: $squid_image"
+                echo -n "$squid_image" > $(results.squid-image.path)
+
+                # Extract caching-tester image
+                tester_image=$(echo "$snapshot" | jq -r '.components[] | select(.name == "caching-tester") | .containerImage')
+                if [ -z "$tester_image" ] || [ "$tester_image" = "null" ]; then
+                  echo "ERROR: Could not find caching-tester component in snapshot"
+                  exit 1
+                fi
+                echo "Tester image: $tester_image"
+                echo -n "$tester_image" > $(results.caching-tester-image.path)
+        params:
+          - name: SNAPSHOT
+            value: $(params.SNAPSHOT)
+
+      # Provision EaaS namespace
+      - name: provision-eaas-space
+        when:
+          - input: "$(tasks.test-metadata.results.test-event-type)"
+            operator: in
+            values: ["pull_request", "push", ""]
+        runAfter:
+          - test-metadata
+        taskRef:
+          resolver: git
+          params:
+            - name: url
+              value: https://github.com/konflux-ci/build-definitions.git
+            - name: revision
+              value: main
+            - name: pathInRepo
+              value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+        params:
+          - name: ownerName
+            value: $(context.pipelineRun.name)
+          - name: ownerUid
+            value: $(context.pipelineRun.uid)
+
+      # Provision ephemeral cluster
+      - name: provision-cluster
+        when:
+          - input: "$(tasks.test-metadata.results.test-event-type)"
+            operator: in
+            values: ["pull_request", "push", ""]
+        runAfter:
+          - provision-eaas-space
+        taskSpec:
+          results:
+            - name: clusterName
+              value: "$(steps.create-cluster.results.clusterName)"
+          steps:
+            - name: get-supported-versions
+              ref:
+                resolver: git
+                params:
+                  - name: url
+                    value: https://github.com/konflux-ci/build-definitions.git
+                  - name: revision
+                    value: main
+                  - name: pathInRepo
+                    value: stepactions/eaas-get-supported-ephemeral-cluster-versions/0.1/eaas-get-supported-ephemeral-cluster-versions.yaml
+              params:
+                - name: eaasSpaceSecretRef
+                  value: $(tasks.provision-eaas-space.results.secretRef)
+            - name: get-latest-version
+              ref:
+                resolver: git
+                params:
+                  - name: url
+                    value: https://github.com/konflux-ci/build-definitions.git
+                  - name: revision
+                    value: main
+                  - name: pathInRepo
+                    value: stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
+              params:
+                - name: prefix
+                  value: "$(steps.get-supported-versions.results.versions[0])."
+            - name: create-cluster
+              ref:
+                resolver: git
+                params:
+                  - name: url
+                    value: https://github.com/konflux-ci/build-definitions.git
+                  - name: revision
+                    value: main
+                  - name: pathInRepo
+                    value: stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
+              params:
+                - name: eaasSpaceSecretRef
+                  value: $(tasks.provision-eaas-space.results.secretRef)
+                - name: version
+                  value: "$(steps.get-latest-version.results.version)"
+                - name: instanceType
+                  value: $(params.machine-type)
+                - name: timeout
+                  value: "45m"
+
+      # Run E2E tests
+      - name: caching-e2e-tests
+        timeout: 2h
+        when:
+          - input: "$(tasks.test-metadata.results.test-event-type)"
+            operator: in
+            values: ["pull_request", "push", ""]
+        runAfter:
+          - provision-cluster
+          - extract-snapshot-images
+        taskSpec:
+          params:
+            - name: squid-image
+            - name: tester-image
+            - name: git-url
+            - name: git-revision
+            - name: helm-version
+          volumes:
+            - name: credentials
+              emptyDir: {}
+          steps:
+            - name: get-kubeconfig
+              ref:
+                resolver: git
+                params:
+                  - name: url
+                    value: https://github.com/konflux-ci/build-definitions.git
+                  - name: revision
+                    value: main
+                  - name: pathInRepo
+                    value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+              params:
+                - name: eaasSpaceSecretRef
+                  value: $(tasks.provision-eaas-space.results.secretRef)
+                - name: clusterName
+                  value: "$(tasks.provision-cluster.results.clusterName)"
+                - name: credentials
+                  value: credentials
+            - name: create-namespace
+              image: quay.io/konflux-ci/konflux-test:v1.5.2@sha256:c370a7bc6e172cdbab001f1a19f37ebc95f47c3d8fe2d915fa4641132490ead7
+              env:
+                - name: KUBECONFIG
+                  value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+              volumeMounts:
+                - name: credentials
+                  mountPath: /credentials
+              script: |
+                #!/bin/bash
+                set -euo pipefail
+                echo "Creating caching namespace on ephemeral cluster..."
+
+                cat <<EOF | oc apply -f -
+                apiVersion: v1
+                kind: Namespace
+                metadata:
+                  name: caching
+                  labels:
+                    app.kubernetes.io/managed-by: Helm
+                  annotations:
+                    meta.helm.sh/release-name: squid
+                    meta.helm.sh/release-namespace: default
+                EOF
+
+                echo "Namespace created with Helm ownership labels"
+            - name: copy-secrets
+              ref:
+                resolver: git
+                params:
+                  - name: url
+                    value: https://github.com/konflux-ci/build-definitions.git
+                  - name: revision
+                    value: main
+                  - name: pathInRepo
+                    value: stepactions/eaas-copy-secrets-to-ephemeral-cluster/0.1/eaas-copy-secrets-to-ephemeral-cluster.yaml
+              params:
+                - name: credentials
+                  value: credentials
+                - name: kubeconfig
+                  value: "$(steps.get-kubeconfig.results.kubeconfig)"
+                - name: namespace
+                  value: "caching"
+                - name: labelSelector
+                  value: "appstudio.redhat.com/internal=true"
+            - name: deploy-and-test
+              image: quay.io/konflux-ci/konflux-test:v1.5.2@sha256:c370a7bc6e172cdbab001f1a19f37ebc95f47c3d8fe2d915fa4641132490ead7
+              env:
+                - name: KUBECONFIG
+                  value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+              volumeMounts:
+                - name: credentials
+                  mountPath: /credentials
+              script: |
+                #!/bin/bash
+                set -euo pipefail
+
+                echo "Using kubeconfig at: $KUBECONFIG"
+
+                # Install helm with pinned version
+                HELM_VERSION="$(params.helm-version)"
+                echo "Installing Helm ${HELM_VERSION}..."
+                curl -fsSL "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz" -o helm.tgz
+                tar -xzf helm.tgz
+                mv linux-amd64/helm /usr/local/bin/helm
+                rm -rf helm.tgz linux-amd64
+                helm version
+
+                # Verify cluster access
+                echo "Verifying OpenShift cluster..."
+                oc version
+                oc auth can-i create customresourcedefinitions || echo "WARNING: No CRD permissions"
+                oc auth can-i '*' '*' --all-namespaces && echo "Confirmed: cluster-admin access" || echo "WARNING: Limited permissions"
+
+                echo "Cloning repository..."
+                git clone $(params.git-url) /workspace/source
+                cd /workspace/source
+                git checkout $(params.git-revision)
+
+                # Use default namespace for Helm release (matches magefile.go behavior)
+                # Resources will be created in "caching" namespace (from chart's values.yaml default)
+                namespace="default"
+
+                # Check for image pull secrets in the resource namespace
+                echo "Checking for image pull secrets in caching namespace..."
+                pull_secrets=$(oc get secrets -n "caching" -o json | \
+                  jq -r '.items[] | select(.type=="kubernetes.io/dockerconfigjson") | .metadata.name' 2>/dev/null || echo "")
+
+                if [ -n "$pull_secrets" ]; then
+                  echo "Found $(echo "$pull_secrets" | wc -w) image pull secret(s)"
+                  secret_args=""
+                  idx=0
+                  for secret in $pull_secrets; do
+                    secret_args="$secret_args --set imagePullSecrets[$idx].name=$secret"
+                    idx=$((idx + 1))
+                  done
+                else
+                  echo "WARNING: No image pull secrets found"
+                  secret_args=""
+                fi
+
+                # Prepare Helm chart with cert-manager dependency
+                echo "Adding jetstack Helm repository..."
+                helm repo add jetstack https://charts.jetstack.io 2>/dev/null || true
+                helm repo update
+                cd caching
+                helm dependency build
+
+                # Parse image references
+                # Handle both tag (repo:tag) and digest (repo@sha256:...) formats
+                squid_img="$(params.squid-image)"
+                if [[ "$squid_img" == *"@"* ]]; then
+                  # Digest format: repo@sha256:digest
+                  squid_repo="${squid_img%@*}"
+                  squid_tag="${squid_img##*@}"
+                else
+                  # Tag format: repo:tag
+                  squid_repo="${squid_img%:*}"
+                  squid_tag="${squid_img##*:}"
+                fi
+
+                tester_img="$(params.tester-image)"
+                if [[ "$tester_img" == *"@"* ]]; then
+                  # Digest format: repo@sha256:digest
+                  tester_repo="${tester_img%@*}"
+                  tester_tag="${tester_img##*@}"
+                else
+                  # Tag format: repo:tag
+                  tester_repo="${tester_img%:*}"
+                  tester_tag="${tester_img##*:}"
+                fi
+
+                echo "Squid: $squid_repo:$squid_tag"
+                echo "Tester: $tester_repo:$tester_tag"
+
+                # Install squid with bundled cert-manager, overriding runAsUser to be OpenShift SCC compatible
+                # OpenShift's restricted-v2 SCC requires UIDs in namespace-specific ranges (e.g., 1000740000-1000749999)
+                # By not specifying runAsUser/runAsGroup/fsGroup, OpenShift will auto-assign from the allowed range
+                # Note: Using installCRDs=false to let caching/crds/ directory handle CRDs (avoids ownership conflicts)
+                echo "Installing Squid chart with cert-manager..."
+                helm install squid . \
+                  --namespace "$namespace" \
+                  --set environment=prerelease \
+                  --set envSettings.prerelease.squid.image.repository="$squid_repo" \
+                  --set envSettings.prerelease.squid.image.tag="$squid_tag" \
+                  --set envSettings.prerelease.test.image.repository="$tester_repo" \
+                  --set envSettings.prerelease.test.image.tag="$tester_tag" \
+                  --set mirrord.enabled=false \
+                  --set installCertManagerComponents=true \
+                  --set cert-manager.enabled=true \
+                  --set cert-manager.installCRDs=false \
+                  --set cert-manager.securityContext.runAsUser=null \
+                  --set cert-manager.securityContext.runAsGroup=null \
+                  --set cert-manager.securityContext.fsGroup=null \
+                  --set nginx.enabled=true \
+                  $secret_args \
+                  --wait \
+                  --timeout=5m \
+                  --debug
+
+                echo "Squid deployed successfully!"
+
+                echo "Running Helm tests..."
+                if ! helm test squid --namespace "$namespace" --timeout 90m; then
+                  echo "ERROR: Helm test failed!"
+                  echo "=== squid-test pod logs (failure) ==="
+                  oc logs -n "caching" squid-test --tail=2000 2>&1 || true
+                  exit 1
+                fi
+
+                echo "Helm tests succeeded, capturing squid-test logs for diagnostics..."
+                echo "=== squid-test pod logs (success) ==="
+                oc logs -n "caching" squid-test --tail=2000 2>&1 || true
+
+                echo "All E2E tests passed!"
+        params:
+          - name: squid-image
+            value: "$(tasks.extract-snapshot-images.results.squid-image)"
+          - name: tester-image
+            value: "$(tasks.extract-snapshot-images.results.caching-tester-image)"
+          - name: git-url
+            value: "$(tasks.test-metadata.results.git-url)"
+          - name: git-revision
+            value: "$(tasks.test-metadata.results.git-revision)"
+          - name: helm-version
+            value: "$(params.helm-version)"
+
+    finally:
+      - name: cleanup-report
+        taskSpec:
+          steps:
+            - name: report
+              image: registry.redhat.io/ubi9/ubi-minimal:latest
+              script: |
+                #!/bin/bash
+                echo "Cleanup complete"
+                echo "Ephemeral cluster will auto-delete after 2 hours"


### PR DESCRIPTION
Create new EaaS test pipeline that uses the caching-tester component instead of squid-tester. This allows testing the renamed component.

Assisted-By: Claude Code

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [ ] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
