### PR TITLE
renovate: disable indirect Go module updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -64,10 +64,9 @@
   ],
   "packageRules": [
     {
-      "description": "Disable major version updates for indirect Go dependencies since they are resolved by go mod tidy based on direct dependency requirements",
+      "description": "Disable Renovate updates for indirect Go dependencies since they are resolved by go mod tidy based on direct dependency requirements",
       "matchManagers": ["gomod"],
       "matchDepTypes": ["indirect"],
-      "matchUpdateTypes": ["major"],
       "enabled": false
     },
     {


### PR DESCRIPTION
## Summary
- Disable Renovate updates for indirect-only Go module dependencies via `gomod.packageRules`
- Indirect deps are resolved by `go mod tidy` when direct dependencies change

## Test plan
- [ ] Verify Renovate config is valid JSON
- [ ] Confirm MintMaker/Renovate no longer opens PRs for indirect-only gomod updates

Made with [Cursor](https://cursor.com)