### PR TITLE
chore: enable hermetic builds for caching pipelines

### DIFF
--- a/.tekton/access-log-exporter-pull-request.yaml
+++ b/.tekton/access-log-exporter-pull-request.yaml
@@ -35,6 +35,12 @@ spec:
     value: .
   - name: TARGET_STAGE
     value: access-log-exporter
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[{"type": "gomod", "path": "."}, {"type": "rpm", "path": "."}]'
+  - name: enable-cache-proxy
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/access-log-exporter-push.yaml
+++ b/.tekton/access-log-exporter-push.yaml
@@ -31,6 +31,12 @@ spec:
     value: .
   - name: TARGET_STAGE
     value: access-log-exporter
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '[{"type": "gomod", "path": "."}, {"type": "rpm", "path": "."}]'
+  - name: enable-cache-proxy
+    value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.

--- a/.tekton/caching-helm-pull-request.yaml
+++ b/.tekton/caching-helm-pull-request.yaml
@@ -34,7 +34,7 @@ spec:
     - name: path-context
       value: "caching"
     - name: hermetic
-      value: "false"
+      value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building Helm charts while maintaining trust after pipeline customization.

--- a/.tekton/caching-helm-push.yaml
+++ b/.tekton/caching-helm-push.yaml
@@ -28,7 +28,7 @@ spec:
     - name: path-context
       value: "caching"
     - name: hermetic
-      value: "false"
+      value: "true"
   pipelineSpec:
     description: |
       This pipeline is ideal for building Helm charts while maintaining trust after pipeline customization.

--- a/.tekton/caching-tester-pull-request.yaml
+++ b/.tekton/caching-tester-pull-request.yaml
@@ -34,7 +34,7 @@ spec:
   - name: path-context
     value: .
   - name: hermetic
-    value: "false"
+    value: "true"
   - name: prefetch-input
     value: '[{"type": "gomod", "path": "."}, {"type": "rpm", "path": "."}]'
   - name: enable-cache-proxy

--- a/.tekton/caching-tester-push.yaml
+++ b/.tekton/caching-tester-push.yaml
@@ -30,7 +30,7 @@ spec:
   - name: path-context
     value: .
   - name: hermetic
-    value: "false"
+    value: "true"
   - name: prefetch-input
     value: '[{"type": "gomod", "path": "."}, {"type": "rpm", "path": "."}]'
   - name: enable-cache-proxy

--- a/.tekton/squid-pull-request.yaml
+++ b/.tekton/squid-pull-request.yaml
@@ -34,7 +34,7 @@ spec:
   - name: path-context
     value: .
   - name: hermetic
-    value: "false"
+    value: "true"
   - name: prefetch-input
     value: '[{"type": "gomod", "path": "."}, {"type": "rpm", "path": "."}]'
   - name: enable-cache-proxy

--- a/.tekton/squid-push.yaml
+++ b/.tekton/squid-push.yaml
@@ -29,7 +29,7 @@ spec:
   - name: path-context
     value: .
   - name: hermetic
-    value: "false"
+    value: "true"
   - name: prefetch-input
     value: '[{"type": "gomod", "path": "."}, {"type": "rpm", "path": "."}]'
   - name: enable-cache-proxy


### PR DESCRIPTION
hermetic builds were enabled in the past and then disabled. Enabling once again.

Assisted-by: Cursor

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [x] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
