### PR TITLE
feat(KONFLUX-15072): make nginx proxy_read_timeout configurable

### DIFF
--- a/caching/templates/nginx-configmap.yaml
+++ b/caching/templates/nginx-configmap.yaml
@@ -75,6 +75,11 @@ data:
         # from /etc/resolv.conf to ensure portability across clusters.
         resolver __RESOLVER__ valid=60s;
         resolver_timeout 5s;
+
+        # Maximum time to wait for the upstream (or redirect target like S3)
+        # to send a response. Applies to all proxy_pass locations, including
+        # the named redirect handler where large artifacts are fetched and cached.
+        proxy_read_timeout {{ .Values.nginx.upstream.readTimeout }};
         
         # Metrics endpoint for access-log-exporter to scrape basic NGINX stats.
         # Provides connection and request counts for the nginx_up metric.

--- a/caching/values.schema.json
+++ b/caching/values.schema.json
@@ -670,6 +670,10 @@
             "url": {
               "type": "string",
               "description": "URL of the upstream server to proxy to"
+            },
+            "readTimeout": {
+              "type": "string",
+              "description": "Timeout for reading a response from the upstream server (nginx time format: 60s, 5m)"
             }
           },
           "required": ["url"],

--- a/caching/values.yaml
+++ b/caching/values.yaml
@@ -448,6 +448,8 @@ nginx:
   upstream:
     # URL of the upstream server to proxy to
     url: "http://nginx-test-backend.caching.svc.cluster.local:9090"
+    # Timeout for reading a response from the upstream server (nginx time format: 60s, 5m)
+    readTimeout: "180s"
 
   # Authorization header injection (references existing Kubernetes secret)
   auth:

--- a/tests/helm/nginx_template_test.go
+++ b/tests/helm/nginx_template_test.go
@@ -493,6 +493,37 @@ var _ = Describe("Helm Template Nginx Configuration", func() {
 			// Host header should be derived from the upstream URL
 			Expect(strings.Count(configMap, "proxy_set_header Host nexus.example.com:8081")).To(Equal(2), "Should derive Host header from upstream URL in both locations")
 		})
+
+		It("should use default proxy_read_timeout when not specified", func() {
+			output, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{
+				Nginx: &testhelpers.NginxValues{
+					Enabled: true,
+					Upstream: &testhelpers.NginxUpstreamValues{
+						URL: "http://nexus.example.com:8081",
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			configMap := extractNginxConfigMapSection(output)
+			Expect(configMap).To(ContainSubstring("proxy_read_timeout 180s;"), "Should use default proxy_read_timeout of 180s")
+		})
+
+		It("should allow overriding proxy_read_timeout", func() {
+			output, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{
+				Nginx: &testhelpers.NginxValues{
+					Enabled: true,
+					Upstream: &testhelpers.NginxUpstreamValues{
+						URL:         "http://nexus.example.com:8081",
+						ReadTimeout: "300s",
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			configMap := extractNginxConfigMapSection(output)
+			Expect(configMap).To(ContainSubstring("proxy_read_timeout 300s;"), "Should use overridden proxy_read_timeout")
+		})
 	})
 
 	Describe("Nginx TLS Configuration", func() {

--- a/tests/testhelpers/nginx_helpers.go
+++ b/tests/testhelpers/nginx_helpers.go
@@ -45,7 +45,8 @@ type NginxTLSValues struct {
 
 // NginxUpstreamValues holds upstream server configuration
 type NginxUpstreamValues struct {
-	URL string `json:"url,omitempty"`
+	URL         string `json:"url,omitempty"`
+	ReadTimeout string `json:"readTimeout,omitempty"`
 }
 
 // NginxAuthValues holds authorization header injection configuration


### PR DESCRIPTION
Large upstream artifacts (e.g. openshift/kubernetes module zips) can take longer than nginx's default 60s read timeout to fetch, causing 502 errors. This adds a configurable readTimeout under nginx.upstream with a default of 180s.

Assisted-by: Claude claude-opus-4-6

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [x] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
