### PR TITLE
fix: add squid.enabled check to ServiceMonitor condition

### DIFF
--- a/caching/templates/servicemonitor.yaml
+++ b/caching/templates/servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.squidExporter.enabled .Values.prometheus.serviceMonitor.enabled }}
+{{- if and .Values.squid.enabled .Values.squidExporter.enabled .Values.prometheus.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/tests/helm/helpers_test.go
+++ b/tests/helm/helpers_test.go
@@ -81,3 +81,8 @@ func extractNginxExporterConfigMapSection(helmOutput string) string {
 func extractNginxServiceMonitorSection(helmOutput string) string {
 	return extractSection(helmOutput, "# Source: caching/templates/nginx-servicemonitor.yaml")
 }
+
+// extractSquidServiceMonitorSection extracts just the squid servicemonitor YAML for precise testing
+func extractSquidServiceMonitorSection(helmOutput string) string {
+	return extractSection(helmOutput, "# Source: caching/templates/servicemonitor.yaml")
+}

--- a/tests/helm/squid_servicemonitor_template_test.go
+++ b/tests/helm/squid_servicemonitor_template_test.go
@@ -1,0 +1,95 @@
+package helm_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/konflux-ci/caching/tests/testhelpers"
+)
+
+var _ = Describe("Helm Template Squid ServiceMonitor Configuration", func() {
+	Describe("Squid ServiceMonitor Rendering Conditions", func() {
+		It("should not render ServiceMonitor when squid is disabled", func() {
+			output, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{
+				Squid: &testhelpers.SquidValues{
+					Enabled: testhelpers.BoolPtr(false),
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			serviceMonitor := extractSquidServiceMonitorSection(output)
+			Expect(serviceMonitor).To(BeEmpty(), "ServiceMonitor should not be rendered when squid.enabled=false")
+		})
+
+		It("should not render ServiceMonitor when squidExporter is disabled", func() {
+			output, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{
+				SquidExporter: &testhelpers.SquidExporterValues{
+					Enabled: testhelpers.BoolPtr(false),
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			serviceMonitor := extractSquidServiceMonitorSection(output)
+			Expect(serviceMonitor).To(BeEmpty(), "ServiceMonitor should not be rendered when squidExporter.enabled=false")
+		})
+
+		It("should not render ServiceMonitor when prometheus.serviceMonitor is disabled", func() {
+			output, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{
+				Prometheus: &testhelpers.PrometheusValues{
+					ServiceMonitor: &testhelpers.ServiceMonitorValues{
+						Enabled: testhelpers.BoolPtr(false),
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			serviceMonitor := extractSquidServiceMonitorSection(output)
+			Expect(serviceMonitor).To(BeEmpty(), "ServiceMonitor should not be rendered when prometheus.serviceMonitor.enabled=false")
+		})
+
+		It("should not render ServiceMonitor when multiple components are disabled", func() {
+			output, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{
+				Squid: &testhelpers.SquidValues{
+					Enabled: testhelpers.BoolPtr(false),
+				},
+				SquidExporter: &testhelpers.SquidExporterValues{
+					Enabled: testhelpers.BoolPtr(false),
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			serviceMonitor := extractSquidServiceMonitorSection(output)
+			Expect(serviceMonitor).To(BeEmpty(), "ServiceMonitor should not be rendered when multiple components are disabled")
+		})
+
+		It("should render ServiceMonitor when all three conditions are enabled (default behavior)", func() {
+			output, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{})
+			Expect(err).NotTo(HaveOccurred())
+
+			serviceMonitor := extractSquidServiceMonitorSection(output)
+			Expect(serviceMonitor).NotTo(BeEmpty(), "ServiceMonitor should be rendered when all conditions are true (default)")
+			Expect(serviceMonitor).To(ContainSubstring("kind: ServiceMonitor"))
+		})
+
+		It("should render ServiceMonitor when all three conditions are explicitly enabled", func() {
+			output, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{
+				Squid: &testhelpers.SquidValues{
+					Enabled: testhelpers.BoolPtr(true),
+				},
+				SquidExporter: &testhelpers.SquidExporterValues{
+					Enabled: testhelpers.BoolPtr(true),
+				},
+				Prometheus: &testhelpers.PrometheusValues{
+					ServiceMonitor: &testhelpers.ServiceMonitorValues{
+						Enabled: testhelpers.BoolPtr(true),
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			serviceMonitor := extractSquidServiceMonitorSection(output)
+			Expect(serviceMonitor).NotTo(BeEmpty(), "ServiceMonitor should be rendered when all three conditions are explicitly true")
+			Expect(serviceMonitor).To(ContainSubstring("kind: ServiceMonitor"))
+		})
+	})
+})

--- a/tests/testhelpers/proxy_test_helpers.go
+++ b/tests/testhelpers/proxy_test_helpers.go
@@ -394,11 +394,13 @@ type ServiceValues struct {
 }
 
 type SquidValues struct {
-	Name string `json:"name,omitempty"`
+	Enabled *bool  `json:"enabled,omitempty"`
+	Name    string `json:"name,omitempty"`
 }
 
 type SquidHelmValues struct {
 	Squid              *SquidValues              `json:"squid,omitempty"`
+	SquidExporter      *SquidExporterValues      `json:"squidExporter,omitempty"`
 	Cache              *CacheValues              `json:"cache,omitempty"`
 	Environment        string                    `json:"environment,omitempty"`
 	ReplicaCount       int                       `json:"replicaCount,omitempty"`
@@ -411,6 +413,11 @@ type SquidHelmValues struct {
 	Prometheus         *PrometheusValues         `json:"prometheus,omitempty"`
 }
 
+// SquidExporterValues holds squid-exporter configuration
+type SquidExporterValues struct {
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
 // PrometheusValues holds Prometheus monitoring configuration
 type PrometheusValues struct {
 	ServiceMonitor *ServiceMonitorValues `json:"serviceMonitor,omitempty"`
@@ -418,6 +425,7 @@ type PrometheusValues struct {
 
 // ServiceMonitorValues holds ServiceMonitor configuration
 type ServiceMonitorValues struct {
+	Enabled  *bool                  `json:"enabled,omitempty"`
 	NginxTLS *NginxTLSMonitorValues `json:"nginxTLS,omitempty"`
 }
 
@@ -430,6 +438,12 @@ type NginxTLSMonitorValues struct {
 type CAValues struct {
 	ConfigMapName string `json:"configMapName,omitempty"`
 	Key           string `json:"key,omitempty"`
+}
+
+// BoolPtr is a helper function to create a pointer to a bool value.
+// Used in tests to explicitly set boolean values that use pointer types with omitempty.
+func BoolPtr(b bool) *bool {
+	return &b
 }
 
 // parseImageReference extracts repository and tag from an image reference


### PR DESCRIPTION
The ServiceMonitor was being created even when squid was disabled because the template condition only checked squidExporter.enabled and prometheus.serviceMonitor.enabled.

This adds .Values.squid.enabled to the condition, making it consistent with other squid templates (deployment, service, configmap, etc.) which all check squid.enabled before creating resources.

Assisted-By: Claude Code

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [ ] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
