### PR TITLE
chore(KFLUXVNGD-1137): Add namespace.create flag for external namespace management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Local and CI use dedicated checks; most are **not** run inside the devcontainer 
 
 ## Conventions
 - Use **Podman**, not Docker — all Mage targets call `podman`
-- Chart creates its own `caching` namespace — don't pass `helm -n caching`, the chart manages it
+- Chart creates its own `caching` namespace by default (`namespace.create: true`) — when deploying standalone, don't pass `helm -n caching`. Set `namespace.create: false` when the namespace is managed externally (e.g., by another chart instance)
 - E2E tests require `CGO_ENABLED=1` and mirrord installed
 - Go tests use **Ginkgo/Gomega** BDD framework
 - Filter tests: `GINKGO_LABEL_FILTER='!external-deps' mage test:cluster`

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ helm install squid ./caching --set environment=dev --set nginx.enabled=true
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `environment` | `release` | `dev` (local images), `prerelease`, `release` (Quay) |
+| `namespace.create` | `true` | Create the namespace (set `false` if managed externally) |
 | `installCertManagerComponents` | `true` | Deploy cert-manager and trust-manager |
 | `selfsigned-bundle.enabled` | `true` | Create trust bundle resource |
 | `selfsigned-certificate.enabled` | `true` | Create certificate resources |

--- a/caching/Chart.yaml
+++ b/caching/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: caching
 description: A Helm chart for deploying caching infrastructure (Squid forward proxy + Nginx reverse proxy)
-# NOTE: This chart creates its own namespace - do not use --namespace with helm commands
+# NOTE: By default this chart creates its own namespace. Set namespace.create=false for external namespace management.
 
 # A chart can be either an 'application' or a 'library' chart.
 #

--- a/caching/templates/namespace.yaml
+++ b/caching/templates/namespace.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.namespace.create }}
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -7,4 +8,5 @@ metadata:
 {{- if .Values.namespace.annotations }}
   annotations:
 {{ toYaml .Values.namespace.annotations | indent 4 }}
+{{- end }}
 {{- end }} 

--- a/caching/values.schema.json
+++ b/caching/values.schema.json
@@ -369,6 +369,10 @@
           "pattern": "caching",
           "description": "Namespace name"
         },
+        "create": {
+          "type": "boolean",
+          "description": "Whether to create the namespace. Set to false if namespace is managed externally."
+        },
         "annotations": {
           "type": "object",
           "additionalProperties": {
@@ -377,7 +381,7 @@
           "description": "Namespace annotations"
         }
       },
-      "required": ["name"],
+      "required": ["name", "create"],
       "additionalProperties": false
     },
     "installCertManagerComponents": {

--- a/caching/values.yaml
+++ b/caching/values.yaml
@@ -273,11 +273,14 @@ tolerations: []
 # Uncomment the affinity section below to customize or disable these defaults
 # affinity: {}
 
-# IMPORTANT: This chart creates and manages its own namespace via templates/namespace.yaml
-# DO NOT use `helm install --namespace` or `helm upgrade --namespace` with this chart
-# All resources will be deployed to the namespace specified below
+# Namespace configuration
+# - When namespace.create=true (default): Chart creates and manages the namespace.
+#   DO NOT use `helm install --namespace` in this mode.
+# - When namespace.create=false: Namespace must exist beforehand (managed externally).
+#   Use `helm install --namespace <name>` to target the existing namespace.
 namespace:
   name: caching
+  create: true  # Set to false if namespace is managed externally (e.g., by another component)
   annotations: {}
 
 # Cert-manager and Trust-manager installation control


### PR DESCRIPTION
Allow namespace to be managed externally by adding a create flag. When namespace.create is set to false, the chart skips creating the namespace resource, allowing it to be created by another component or pre-existing infrastructure.

This enables independent deployment scenarios where multiple components share a namespace but only one should own its creation.

**Why:**
Resolves SharedResourceWarning when multiple ArgoCD applications (e.g., squid and artifact-registry-proxy) deploy to the same namespace using this chart.

Jira-Url: https://redhat.atlassian.net/browse/KFLUXVNGD-1137
Assisted-by: Claude Code

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [ ] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
