### PR TITLE
feat(KFLUXVNGD-836): Add OpenShift-CI E2E pipeline and rename test pod

### DIFF
--- a/.tekton/caching-openshift-e2e-tests.yaml
+++ b/.tekton/caching-openshift-e2e-tests.yaml
@@ -11,43 +11,31 @@ metadata:
     appstudio.openshift.io/application: caching
     appstudio.openshift.io/component: caching-tester
     pipelines.appstudio.openshift.io/type: test
-  name: caching-e2e-eaas-test
+  name: caching-openshift-e2e-tests
   namespace: konflux-vanguard-tenant
 spec:
   params:
-    - name: test-name
-      value: caching-openshift-e2e
     - name: ocp-version
-      value: "4.17"
-    - name: test-event-type
-      value: pull_request
+      value: "4.21"
     - name: machine-type
       value: m5.xlarge
 
   pipelineSpec:
     description: |-
       This pipeline automates the process of running end-to-end tests for Caching
-      on an ephemeral OpenShift cluster using EaaS (Environment as a Service).
+      on an ephemeral OpenShift cluster provisioned via OpenShift-CI.
       It runs on pull_request events and uses PR build images directly.
     params:
       - name: SNAPSHOT
         description: 'JSON string containing the application components and their container images'
         default: '{"components": []}'
         type: string
-      - name: test-name
-        description: 'The name of the test corresponding to a defined Konflux integration test.'
-        default: 'caching-e2e'
       - name: ocp-version
         description: 'The OpenShift version to use for the ephemeral cluster deployment.'
         type: string
-        default: "4.17"
-      - name: test-event-type
-        description: 'Indicates if the test is triggered by a Pull Request or Push event.'
-        default: 'pull_request'
       - name: machine-type
         description: 'The EC2 instance type for cluster worker nodes (amd64 or arm64).'
         type: string
-        default: "m5.xlarge"
       - name: helm-version
         description: 'The Helm version to install and use for deployments.'
         type: string
@@ -66,14 +54,10 @@ spec:
         params:
           - name: SNAPSHOT
             value: $(params.SNAPSHOT)
-          - name: test-name
-            value: $(context.pipelineRun.name)
 
       # Extract component images from the snapshot
       # The snapshot contains all built component images for this PR
       - name: extract-snapshot-images
-        runAfter:
-          - test-metadata
         taskSpec:
           params:
             - name: SNAPSHOT
@@ -115,134 +99,56 @@ spec:
           - name: SNAPSHOT
             value: $(params.SNAPSHOT)
 
-      # Provision EaaS namespace
-      - name: provision-eaas-space
-        when:
-          - input: "$(tasks.test-metadata.results.test-event-type)"
-            operator: in
-            values: ["pull_request", "push", ""]
-        runAfter:
-          - test-metadata
+      # Provision ephemeral cluster
+      - name: provision-cluster
         taskRef:
           resolver: git
           params:
             - name: url
-              value: https://github.com/konflux-ci/build-definitions.git
+              value: https://github.com/openshift/konflux-tasks
             - name: revision
-              value: main
+              value: 5fb29d2447b801ff050d0f4d4285615f8ca75f2f
             - name: pathInRepo
-              value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+              value: tasks/provision-ephemeral-cluster/0.1/provision-ephemeral-cluster.yaml
         params:
           - name: ownerName
             value: $(context.pipelineRun.name)
           - name: ownerUid
             value: $(context.pipelineRun.uid)
+          - name: clusterProfile
+            value: aws-konflux-prod
+          - name: workflow
+            value: hypershift-hostedcluster-workflow
+          - name: env
+            value: '{"COMPUTE_NODE_TYPE": "$(params.machine-type)", "HYPERSHIFT_NODE_COUNT": "3"}'
+          - name: releases
+            value: |
+              {"latest":{"release":{"channel":"stable","version":"$(params.ocp-version)","architecture":"multi"}}}
 
-      # Provision ephemeral cluster
-      - name: provision-cluster
-        when:
-          - input: "$(tasks.test-metadata.results.test-event-type)"
-            operator: in
-            values: ["pull_request", "push", ""]
-        runAfter:
-          - provision-eaas-space
-        taskSpec:
-          results:
-            - name: clusterName
-              value: "$(steps.create-cluster.results.clusterName)"
-          steps:
-            - name: get-supported-versions
-              ref:
-                resolver: git
-                params:
-                  - name: url
-                    value: https://github.com/konflux-ci/build-definitions.git
-                  - name: revision
-                    value: main
-                  - name: pathInRepo
-                    value: stepactions/eaas-get-supported-ephemeral-cluster-versions/0.1/eaas-get-supported-ephemeral-cluster-versions.yaml
-              params:
-                - name: eaasSpaceSecretRef
-                  value: $(tasks.provision-eaas-space.results.secretRef)
-            - name: get-latest-version
-              ref:
-                resolver: git
-                params:
-                  - name: url
-                    value: https://github.com/konflux-ci/build-definitions.git
-                  - name: revision
-                    value: main
-                  - name: pathInRepo
-                    value: stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
-              params:
-                - name: prefix
-                  value: "$(steps.get-supported-versions.results.versions[0])."
-            - name: create-cluster
-              ref:
-                resolver: git
-                params:
-                  - name: url
-                    value: https://github.com/konflux-ci/build-definitions.git
-                  - name: revision
-                    value: main
-                  - name: pathInRepo
-                    value: stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
-              params:
-                - name: eaasSpaceSecretRef
-                  value: $(tasks.provision-eaas-space.results.secretRef)
-                - name: version
-                  value: "$(steps.get-latest-version.results.version)"
-                - name: instanceType
-                  value: $(params.machine-type)
-                - name: timeout
-                  value: "45m"
-
-      # Run E2E tests
-      - name: caching-e2e-tests
-        timeout: 2h
-        when:
-          - input: "$(tasks.test-metadata.results.test-event-type)"
-            operator: in
-            values: ["pull_request", "push", ""]
+      # Create namespace on the ephemeral cluster for secret copying and deployment
+      - name: create-namespace
         runAfter:
           - provision-cluster
-          - extract-snapshot-images
+        params:
+          - name: kubeconfigSecretRef
+            value: $(tasks.provision-cluster.results.secretRef)
         taskSpec:
           params:
-            - name: squid-image
-            - name: tester-image
-            - name: git-url
-            - name: git-revision
-            - name: helm-version
+            - name: kubeconfigSecretRef
           volumes:
-            - name: credentials
-              emptyDir: {}
+            - name: cluster-credentials
+              secret:
+                secretName: $(params.kubeconfigSecretRef)
           steps:
-            - name: get-kubeconfig
-              ref:
-                resolver: git
-                params:
-                  - name: url
-                    value: https://github.com/konflux-ci/build-definitions.git
-                  - name: revision
-                    value: main
-                  - name: pathInRepo
-                    value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
-              params:
-                - name: eaasSpaceSecretRef
-                  value: $(tasks.provision-eaas-space.results.secretRef)
-                - name: clusterName
-                  value: "$(tasks.provision-cluster.results.clusterName)"
-                - name: credentials
-                  value: credentials
             - name: create-namespace
               image: quay.io/konflux-ci/konflux-test:v1.5.4@sha256:dae74bf0d6fc349d3ae140d9e3a921ad5009fdf8dade3186bfd9b65fbe3a365b
               env:
                 - name: KUBECONFIG
-                  value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+                  value: /var/run/secrets/cluster/kubeconfig
               volumeMounts:
-                - name: credentials
-                  mountPath: /credentials
+                - name: cluster-credentials
+                  mountPath: /var/run/secrets/cluster
+                  readOnly: true
               script: |
                 #!/bin/bash
                 set -euo pipefail
@@ -256,43 +162,77 @@ spec:
                   labels:
                     app.kubernetes.io/managed-by: Helm
                   annotations:
-                    meta.helm.sh/release-name: squid
+                    meta.helm.sh/release-name: caching
                     meta.helm.sh/release-namespace: default
                 EOF
 
                 echo "Namespace created with Helm ownership labels"
-            - name: copy-secrets
-              ref:
-                resolver: git
-                params:
-                  - name: url
-                    value: https://github.com/konflux-ci/build-definitions.git
-                  - name: revision
-                    value: main
-                  - name: pathInRepo
-                    value: stepactions/eaas-copy-secrets-to-ephemeral-cluster/0.1/eaas-copy-secrets-to-ephemeral-cluster.yaml
-              params:
-                - name: credentials
-                  value: credentials
-                - name: kubeconfig
-                  value: "$(steps.get-kubeconfig.results.kubeconfig)"
-                - name: namespace
-                  value: "caching"
-                - name: labelSelector
-                  value: "appstudio.redhat.com/internal=true"
+
+      # Copy secrets from Konflux namespace to the ephemeral cluster
+      - name: copy-secrets
+        runAfter:
+          - create-namespace
+        taskRef:
+          resolver: git
+          params:
+            - name: url
+              value: https://github.com/openshift/konflux-tasks
+            - name: revision
+              value: 5fb29d2447b801ff050d0f4d4285615f8ca75f2f
+            - name: pathInRepo
+              value: tasks/copy-secrets-to-ephemeral-cluster/0.1/copy-secrets-to-ephemeral-cluster.yaml
+        params:
+          - name: clusterCredentialsSecretRef
+            value: $(tasks.provision-cluster.results.secretRef)
+          - name: namespace
+            value: caching
+          - name: labelSelector
+            value: "appstudio.redhat.com/internal=true"
+
+      - name: e2e-tests
+        timeout: 2h
+        runAfter:
+          - test-metadata
+          - extract-snapshot-images
+          - copy-secrets
+        params:
+          - name: kubeconfigSecretRef
+            value: $(tasks.provision-cluster.results.secretRef)
+          - name: squid-image
+            value: "$(tasks.extract-snapshot-images.results.squid-image)"
+          - name: tester-image
+            value: "$(tasks.extract-snapshot-images.results.caching-tester-image)"
+          - name: git-url
+            value: "$(tasks.test-metadata.results.git-url)"
+          - name: git-revision
+            value: "$(tasks.test-metadata.results.git-revision)"
+          - name: helm-version
+            value: "$(params.helm-version)"
+        taskSpec:
+          params:
+            - name: squid-image
+            - name: tester-image
+            - name: git-url
+            - name: git-revision
+            - name: helm-version
+            - name: kubeconfigSecretRef
+          volumes:
+            - name: cluster-credentials
+              secret:
+                secretName: $(params.kubeconfigSecretRef)
+          steps:
             - name: deploy-and-test
               image: quay.io/konflux-ci/konflux-test:v1.5.4@sha256:dae74bf0d6fc349d3ae140d9e3a921ad5009fdf8dade3186bfd9b65fbe3a365b
               env:
                 - name: KUBECONFIG
-                  value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+                  value: /var/run/secrets/cluster/kubeconfig
               volumeMounts:
-                - name: credentials
-                  mountPath: /credentials
+                - name: cluster-credentials
+                  mountPath: /var/run/secrets/cluster
+                  readOnly: true
               script: |
                 #!/bin/bash
                 set -euo pipefail
-
-                echo "Using kubeconfig at: $KUBECONFIG"
 
                 # Install helm with pinned version
                 HELM_VERSION="$(params.helm-version)"
@@ -370,13 +310,15 @@ spec:
                 echo "Squid: $squid_repo:$squid_tag"
                 echo "Tester: $tester_repo:$tester_tag"
 
-                # Install squid with bundled cert-manager, overriding runAsUser to be OpenShift SCC compatible
+                # Install squid and nginx with bundled cert-manager, overriding runAsUser to be OpenShift SCC compatible
                 # OpenShift's restricted-v2 SCC requires UIDs in namespace-specific ranges (e.g., 1000740000-1000749999)
                 # By not specifying runAsUser/runAsGroup/fsGroup, OpenShift will auto-assign from the allowed range
                 # Note: Using installCRDs=false to let caching/crds/ directory handle CRDs (avoids ownership conflicts)
-                echo "Installing Squid chart with cert-manager..."
-                helm install squid . \
+                echo "Installing caching chart with cert-manager..."
+                helm install caching . \
                   --namespace "$namespace" \
+                  --set nginx.enabled=true \
+                  --set squid.enabled=true \
                   --set environment=prerelease \
                   --set envSettings.prerelease.squid.image.repository="$squid_repo" \
                   --set envSettings.prerelease.squid.image.tag="$squid_tag" \
@@ -389,46 +331,40 @@ spec:
                   --set cert-manager.securityContext.runAsUser=null \
                   --set cert-manager.securityContext.runAsGroup=null \
                   --set cert-manager.securityContext.fsGroup=null \
-                  --set nginx.enabled=true \
                   $secret_args \
                   --wait \
-                  --timeout=5m \
+                  --timeout=10m \
                   --debug
 
-                echo "Squid deployed successfully!"
+                echo "Caching chart deployed successfully!"
 
                 echo "Running Helm tests..."
-                if ! helm test squid --namespace "$namespace" --timeout 90m; then
+                if ! helm test caching --namespace "$namespace" --timeout 90m; then
                   echo "ERROR: Helm test failed!"
-                  echo "=== squid-test pod logs (failure) ==="
-                  oc logs -n "caching" squid-test --tail=2000 2>&1 || true
+                  echo "=== caching-test pod logs (failure) ==="
+                  oc logs -n caching caching-test --tail=2000 2>&1 || true
                   exit 1
                 fi
 
-                echo "Helm tests succeeded, capturing squid-test logs for diagnostics..."
-                echo "=== squid-test pod logs (success) ==="
-                oc logs -n "caching" squid-test --tail=2000 2>&1 || true
+                echo "Helm tests succeeded, capturing caching-test logs for diagnostics..."
+                echo "=== caching-test pod logs (success) ==="
+                oc logs -n caching caching-test --tail=2000 2>&1 || true
 
                 echo "All E2E tests passed!"
-        params:
-          - name: squid-image
-            value: "$(tasks.extract-snapshot-images.results.squid-image)"
-          - name: tester-image
-            value: "$(tasks.extract-snapshot-images.results.caching-tester-image)"
-          - name: git-url
-            value: "$(tasks.test-metadata.results.git-url)"
-          - name: git-revision
-            value: "$(tasks.test-metadata.results.git-revision)"
-          - name: helm-version
-            value: "$(params.helm-version)"
 
     finally:
-      - name: cleanup-report
-        taskSpec:
-          steps:
-            - name: report
-              image: registry.redhat.io/ubi9/ubi-minimal:latest
-              script: |
-                #!/bin/bash
-                echo "Cleanup complete"
-                echo "Ephemeral cluster will auto-delete after 2 hours"
+      - name: deprovision-ephemeral-cluster
+        taskRef:
+          resolver: git
+          params:
+            - name: url
+              value: https://github.com/openshift/konflux-tasks
+            - name: revision
+              value: 5fb29d2447b801ff050d0f4d4285615f8ca75f2f
+            - name: pathInRepo
+              value: tasks/deprovision-ephemeral-cluster/0.1/deprovision-ephemeral-cluster.yaml
+        params:
+          - name: testPlatformClusterClaimName
+            value: $(tasks.provision-cluster.results.testPlatformClusterClaimName)
+          - name: testPlatformClusterClaimNamespace
+            value: $(tasks.provision-cluster.results.testPlatformClusterClaimNamespace)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,6 @@ Forgetting lock files will break Konflux CI. See `HERMETIC-BUILDS.md`.
 
 ## Gotchas
 - **Misleading name**: `access-log-exporter` is for nginx, not squid
-- **Chart directory vs release name**: the Helm chart directory is `caching/` but the default Helm release name remains `squid`
 - **Squid image is multi-process**: runs squid, squid-exporter (:9301), per-site-exporter (:9302), ICAP (:1344)
 - **`.tekton/` changes trigger CI** — edits here affect Pipelines-as-Code
 

--- a/README.md
+++ b/README.md
@@ -95,17 +95,17 @@ curl --proxy http://127.0.0.1:3128 http://httpbin.org/ip
 
 ```bash
 # Full install with cert-manager (default)
-helm install squid ./caching
+helm install caching ./caching
 
 # Without deploying cert-manager (requires cert-manager already installed on the cluster)
 # Note: Certificate resources are still created — cert-manager must be present
-helm install squid ./caching --set installCertManagerComponents=false
+helm install caching ./caching --set installCertManagerComponents=false
 
 # Disable TLS certificate resources (cert-manager still deployed)
-helm install squid ./caching --set installCertManagerComponents=false --set selfsigned-bundle.enabled=false
+helm install caching ./caching --set installCertManagerComponents=false --set selfsigned-bundle.enabled=false
 
 # Local development
-helm install squid ./caching --set environment=dev --set nginx.enabled=true
+helm install caching ./caching --set environment=dev --set nginx.enabled=true
 ```
 
 ### Key Values
@@ -132,7 +132,7 @@ mage test:cluster
 GINKGO_LABEL_FILTER='!external-deps' mage test:cluster
 
 # Direct helm test (requires explicit timeout)
-helm test squid --timeout=420s
+helm test caching --timeout=420s
 ```
 
 The test suite uses [Ginkgo](https://onsi.github.io/ginkgo/) with [mirrord](https://mirrord.dev/) for cluster network access during local development.
@@ -172,7 +172,7 @@ mage cachingHelm:status
 |-------|----------|
 | Cluster exists error | `kind export kubeconfig --name caching` |
 | Image pull errors | `mage build:loadSquid` |
-| Namespace errors | `helm uninstall squid && kubectl delete ns caching` |
+| Namespace errors | `helm uninstall caching && kubectl delete ns caching` |
 | Connection refused | Check squid ACLs cover your pod CIDR |
 
 For detailed troubleshooting, see [docs/troubleshooting.md](docs/troubleshooting.md).
@@ -184,7 +184,7 @@ For detailed troubleshooting, see [docs/troubleshooting.md](docs/troubleshooting
 mage clean
 
 # Manual
-helm uninstall squid
+helm uninstall caching
 kubectl delete namespace caching
 kind delete cluster --name caching
 ```

--- a/caching/templates/mirrord-target-pod.yaml
+++ b/caching/templates/mirrord-target-pod.yaml
@@ -7,14 +7,14 @@ metadata:
   labels:
     # Use different app name to avoid service selector conflicts
     app.kubernetes.io/name: mirrord-target
-    app.kubernetes.io/instance: {{ .Values.squid.name }}
+    app.kubernetes.io/instance: {{ .Values.test.name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/component: mirrord-target
     app: {{ .Values.mirrord.targetPod.name }}
     helm.sh/chart: {{ include "caching.chart" . }}
 spec:
-  serviceAccountName: {{ .Values.squid.name }}-test
+  serviceAccountName: {{ .Values.test.name }}
   restartPolicy: Always  # Keep the target pod running for development
   containers:
     - name: mirrord-target

--- a/caching/templates/test-pod.yaml
+++ b/caching/templates/test-pod.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ .Values.squid.name }}-test"
+  name: "{{ .Values.test.name }}"
   namespace: {{ .Values.namespace.name }}
   labels:
-    # Use different app name to avoid service selector conflicts
-    app.kubernetes.io/name: squid
-    app.kubernetes.io/instance: {{ .Values.squid.name }}
+    # Use different app names from the squid or nginx pods to avoid service selector conflicts
+    app.kubernetes.io/name: {{ .Values.test.name }}
+    app.kubernetes.io/instance: {{ .Values.test.name }}
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/component: test
@@ -20,7 +20,7 @@ metadata:
     "helm.sh/hook-timeout": "9000" # 15 minutes
 spec:
   restartPolicy: Never
-  serviceAccountName: {{ .Values.squid.name }}-test
+  serviceAccountName: {{ .Values.test.name }}
   containers:
   - name: ginkgo-test
     image: "{{ include "caching.test.image" . }}"

--- a/caching/templates/test-rbac.yaml
+++ b/caching/templates/test-rbac.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.squid.name }}-test
+  name: {{ .Values.test.name }}
   namespace: {{ .Values.namespace.name }}
   labels:
     {{- include "caching.squid.labels" . | nindent 4 }}
@@ -18,7 +18,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Values.squid.name }}-test
+  name: {{ .Values.test.name }}
   labels:
     {{- include "caching.squid.labels" . | nindent 4 }}
     app.kubernetes.io/component: test
@@ -58,7 +58,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Values.squid.name }}-test
+  name: {{ .Values.test.name }}
   labels:
     {{- include "caching.squid.labels" . | nindent 4 }}
     app.kubernetes.io/component: test
@@ -71,9 +71,9 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Values.squid.name }}-test
+  name: {{ .Values.test.name }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.squid.name }}-test
+  name: {{ .Values.test.name }}
   namespace: {{ .Values.namespace.name }}
 {{- end }}

--- a/caching/values.schema.json
+++ b/caching/values.schema.json
@@ -478,6 +478,10 @@
     "test": {
       "type": "object",
       "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name used for the test pod, service account, RBAC resources, etc."
+        },
         "enabled": {
           "type": "boolean",
           "description": "Enable helm test functionality"
@@ -502,7 +506,7 @@
           "description": "Label filter for Ginkgo tests"
         }
       },
-      "required": ["enabled"],
+      "required": ["name", "enabled"],
       "additionalProperties": false
     },
     "mirrord": {

--- a/caching/values.yaml
+++ b/caching/values.yaml
@@ -541,6 +541,7 @@ nginx:
 # ============================================================================
 
 test:
+  name: "caching-test"
   enabled: true # Enable helm test functionality
   image:
     pullPolicy: IfNotPresent

--- a/docs/development.md
+++ b/docs/development.md
@@ -188,7 +188,7 @@ kind load image-archive --name caching <(podman save localhost/konflux-ci/cachin
 
 ```bash
 # Deploy for local dev — enables nginx reverse proxy (required for access-log-exporter sidecar)
-helm install squid ./caching --set environment=dev --set nginx.enabled=true
+helm install caching ./caching --set environment=dev --set nginx.enabled=true
 kubectl get pods -n caching
 ```
 
@@ -196,20 +196,20 @@ kubectl get pods -n caching
 
 ```bash
 # Full install with cert-manager
-helm install squid ./caching
+helm install caching ./caching
 
 # Without deploying cert-manager (requires cert-manager already installed on the cluster)
 # Note: Certificate resources are still created — cert-manager must be present
-helm install squid ./caching --set installCertManagerComponents=false
+helm install caching ./caching --set installCertManagerComponents=false
 
 # Install cert-manager + trust-manager without creating certificate resources
-helm install squid ./caching --set selfsigned-issuer.enabled=false
+helm install caching ./caching --set selfsigned-issuer.enabled=false
 
 # Disable TLS certificate resources (cert-manager still deployed)
-helm install squid ./caching --set installCertManagerComponents=false --set selfsigned-bundle.enabled=false
+helm install caching ./caching --set installCertManagerComponents=false --set selfsigned-bundle.enabled=false
 
 # Local development
-helm install squid ./caching --set environment=dev --set nginx.enabled=true
+helm install caching ./caching --set environment=dev --set nginx.enabled=true
 ```
 
 ## Cleanup
@@ -222,7 +222,7 @@ mage clean              # Remove cluster + images (recommended)
 
 ```bash
 # Remove Helm release and namespace
-helm uninstall squid
+helm uninstall caching
 kubectl delete namespace caching
 
 # Remove cert-manager namespace (if installed via chart)

--- a/docs/monitoring-tests.md
+++ b/docs/monitoring-tests.md
@@ -44,7 +44,7 @@ fi
 #### 1.3 Clean Previous Deployments
 ```bash
 # Remove any existing deployment
-helm uninstall squid 2>/dev/null || true
+helm uninstall caching 2>/dev/null || true
 
 # Remove namespace
 kubectl delete namespace caching 2>/dev/null || true
@@ -60,7 +60,7 @@ sleep 10
 #### 2.1 Deploy Squid with Monitoring
 ```bash
 # Deploy with monitoring enabled
-helm install squid ./caching \
+helm install caching ./caching \
   --set squidExporter.enabled=true \
   --set prometheus.serviceMonitor.enabled=true \
   --set cert-manager.enabled=false \
@@ -294,7 +294,7 @@ For rapid testing during development:
 
 ```bash
 # Quick deployment test
-helm install squid ./caching --set cert-manager.enabled=false --wait
+helm install caching ./caching --set cert-manager.enabled=false --wait
 
 # Quick functionality test
 kubectl port-forward -n caching svc/squid 3128:3128 &
@@ -307,5 +307,5 @@ curl -s http://localhost:9301/metrics | grep squid_up
 pkill -f "kubectl port-forward.*9301"
 
 # Quick cleanup
-helm uninstall squid && kubectl delete namespace caching
+helm uninstall caching && kubectl delete namespace caching
 ```

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -73,7 +73,7 @@ The chart includes the ServiceMonitor CRD in the `crds/` directory, so it will b
 
 If you don't want ServiceMonitor functionality, you can disable it:
 ```bash
-helm install squid ./caching --set prometheus.serviceMonitor.enabled=false
+helm install caching ./caching --set prometheus.serviceMonitor.enabled=false
 ```
 
 **For non-Prometheus Operator setups**, disable ServiceMonitor and use manual Prometheus configuration:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -12,14 +12,14 @@ mage all
 mage test:cluster
 ```
 
-> **Note**: `mage all` sets up the complete environment (cluster, images, deployment) and ends by invoking `helm test squid --timeout=15m`. It runs **unit tests** and **Helm-driven tests** — it does not run `mage test:cluster` (mirrord E2E).
+> **Note**: `mage all` sets up the complete environment (cluster, images, deployment) and ends by invoking `helm test caching --timeout=15m`. It runs **unit tests** and **Helm-driven tests** — it does not run `mage test:cluster` (mirrord E2E).
 
 ## Running Tests via Helm
 
 When running `helm test` directly (not through `mage all`), you must specify a timeout of at least 420 seconds:
 
 ```bash
-helm test squid --timeout=420s
+helm test caching --timeout=420s
 ```
 
 The default Helm test timeout is 5 minutes (300 seconds), which may not be sufficient for all tests to complete.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -78,11 +78,11 @@ Look for:
 
 **Solution**: Clean up and reinstall:
 ```bash
-helm uninstall squid 2>/dev/null || true
+helm uninstall caching 2>/dev/null || true
 kubectl delete namespace caching 2>/dev/null || true
 # Wait a few seconds for cleanup
 sleep 5
-helm install squid ./caching
+helm install caching ./caching
 ```
 
 ### 6. Connection Refused from Pods

--- a/magefile.go
+++ b/magefile.go
@@ -450,11 +450,11 @@ func (CachingHelm) Up() error {
 		return fmt.Errorf("failed to build helm dependencies: %w", err)
 	}
 
-	fmt.Printf("⚓ Installing/upgrading caching helm chart (release: squid) and waiting for readiness...\n")
+	fmt.Printf("⚓ Installing/upgrading caching helm chart (release: caching) and waiting for readiness...\n")
 	err = sh.Run(
 		"helm",
 		"upgrade",
-		"squid",
+		"caching",
 		chartPath,
 		"--install",
 		"--set", "environment=dev",
@@ -484,19 +484,19 @@ func (CachingHelm) Down() error {
 	fmt.Println("🗑️  Removing caching Helm chart...")
 
 	// Check if release exists first
-	exists, err := internal.ReleaseExists("squid")
+	exists, err := internal.ReleaseExists("caching")
 	if err != nil {
 		return fmt.Errorf("failed to check release existence: %w", err)
 	}
 
 	if !exists {
-		fmt.Printf("ℹ️  Helm release 'squid' does not exist\n")
+		fmt.Printf("ℹ️  Helm release 'caching' does not exist\n")
 		return nil
 	}
 
 	// Uninstall the helm release
-	fmt.Printf("🗑️  Uninstalling caching helm release (squid)...\n")
-	err = sh.Run("helm", "uninstall", "squid")
+	fmt.Printf("🗑️  Uninstalling caching helm release (caching)...\n")
+	err = sh.Run("helm", "uninstall", "caching")
 	if err != nil {
 		return fmt.Errorf("failed to uninstall helm chart: %w", err)
 	}
@@ -531,11 +531,11 @@ func (CachingHelm) UpClean() error {
 func (CachingHelm) Status() error {
 	fmt.Println("📊 Checking deployment status...")
 
-	// Check if squid helm release exists
+	// Check if caching helm release exists
 	fmt.Printf("🔍 Checking helm release status...\n")
-	err := sh.Run("helm", "status", "squid")
+	err := sh.Run("helm", "status", "caching")
 	if err != nil {
-		fmt.Printf("❌ Helm release 'squid' not found or not deployed\n")
+		fmt.Printf("❌ Helm release 'caching' not found or not deployed\n")
 		return fmt.Errorf("helm release not found: %w", err)
 	}
 
@@ -605,14 +605,14 @@ func All() error {
 	// Run helm tests to validate the deployment
 	fmt.Println()
 	fmt.Println("🧪 Running helm tests to validate deployment...")
-	err = sh.Run("helm", "test", "squid", "--timeout=15m")
+	err = sh.Run("helm", "test", "caching", "--timeout=15m")
 	if err != nil {
 		// Test failed - capture and display logs for debugging
 		fmt.Println()
 		fmt.Println("❌ Helm tests failed! Capturing test pod logs for debugging...")
 		fmt.Println()
 		fmt.Println("=== Squid Test Pod Logs ===")
-		logsError := sh.RunV("kubectl", "logs", "-n", "caching", "squid-test")
+		logsError := sh.RunV("kubectl", "logs", "-n", "caching", "caching-test")
 		if logsError != nil {
 			fmt.Printf("⚠️  Could not retrieve test pod logs: %v\n", logsError)
 		}
@@ -620,7 +620,7 @@ func All() error {
 		return fmt.Errorf("helm tests failed: %w", err)
 	}
 	fmt.Println("✅ All helm tests passed!")
-	// Reset squid helm chart to values.yaml defaults after tests complete
+	// Reset caching helm chart to values.yaml defaults after tests complete
 	resetCachingToDefaults()
 	fmt.Println()
 	fmt.Println("🎉 Complete automation workflow finished successfully!")
@@ -718,7 +718,7 @@ func resetCachingToDefaults() {
 	err := sh.Run(
 		"helm",
 		"upgrade",
-		"squid",
+		"caching",
 		chartPath,
 		"--set", "environment=dev",
 		"--set", "nginx.enabled=true",
@@ -760,7 +760,7 @@ func (Test) ClusterMultiReplica() error {
 	// Upgrade deployment to 3 replicas
 	err := sh.RunWith(map[string]string{
 		"SQUID_REPLICA_COUNT": "3",
-	}, "helm", "upgrade", "squid", chartPath,
+	}, "helm", "upgrade", "caching", chartPath,
 		"-n=default", "--wait", "--timeout=300s", "--history-max=50",
 		"--set", "replicaCount=3",
 		"--set", "nginx.enabled=true",

--- a/skills/running-tests/SKILL.md
+++ b/skills/running-tests/SKILL.md
@@ -5,5 +5,5 @@ description: Gotchas when running unit or E2E tests
 
 # Running Tests
 
-- `mage all` and `mage test:cluster` fail differently: `helm test` failures appear in pod logs (`kubectl logs squid-test-...`), while `test:cluster` failures require a working mirrord binary and an active target pod -- check the latter first if tests hang
+- `mage all` and `mage test:cluster` fail differently: `helm test` failures appear in pod logs (`kubectl logs caching-test-...`), while `test:cluster` failures require a working mirrord binary and an active target pod -- check the latter first if tests hang
 - After cluster tests, Helm release is **reset to defaults** automatically -- don't rely on test-modified state persisting

--- a/test-entrypoint.sh
+++ b/test-entrypoint.sh
@@ -12,7 +12,7 @@ echo "Nginx service: ${NGINX_SERVICE:-nginx.caching.svc.cluster.local:8080}"
 # Build helm chart dependencies in a writable temp directory
 # The /app directory is read-only, so we need to copy the chart to /tmp
 echo "Building helm chart dependencies..."
-helm repo add jetstack https://charts.jetstack.io 2>/dev/null || true
+helm repo add jetstack https://charts.jetstack.io
 helm repo update
 
 # Copy chart to writable temp directory

--- a/tests/testhelpers/proxy_test_helpers.go
+++ b/tests/testhelpers/proxy_test_helpers.go
@@ -579,7 +579,7 @@ func ConfigureSquidWithHelm(ctx context.Context, client kubernetes.Interface, va
 	// Build helm arguments based on environment and platform
 	extraArgs := buildExtraHelmArgs(environment, openshift, statefulSet)
 
-	err = UpgradeChartWithArgs("squid", chartPath, valuesFile, extraArgs)
+	err = UpgradeChartWithArgs("caching", chartPath, valuesFile, extraArgs)
 	if err != nil {
 		return fmt.Errorf("failed to upgrade squid with helm: %w", err)
 	}


### PR DESCRIPTION
Add a new E2E test pipeline that provisions an ephemeral OpenShift cluster via OpenShift-CI integration (openshift/konflux-tasks) instead of EaaS. The pipeline deploys the caching chart with both squid and nginx, copies image pull secrets, and runs Helm tests against the ephemeral cluster.

Rename the test pod from squid-test to caching-test since it validates both squid and nginx services, not just squid.

Assisted-by: Claude claude-opus-4-6

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [x] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
