### PR TITLE
chore(KFLUXVNGD-1161): Add Renovate tracking for openshift/konflux-tasks revision

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -59,6 +59,22 @@
     },
     {
       "customType": "regex",
+      "description": "Track openshift/konflux-tasks main HEAD in pipeline param default",
+      "managerFilePatterns": [
+        "/^\\.tekton/caching-openshift-e2e-tests\\.yaml$/"
+      ],
+      "matchStringsStrategy": "combination",
+      "matchStrings": [
+        "# renovate: datasource=git-refs depName=https://github.com/openshift/konflux-tasks",
+        "default:\\s+(?<currentDigest>[a-f0-9]{40})"
+      ],
+      "datasourceTemplate": "git-refs",
+      "depNameTemplate": "https://github.com/openshift/konflux-tasks",
+      "currentValueTemplate": "main",
+      "autoReplaceStringTemplate": "default: {{newDigest}}"
+    },
+    {
+      "customType": "regex",
       "description": "Track Go version and SHA256 in devcontainer Containerfile",
       "managerFilePatterns": [
         "/^\\.devcontainer/Containerfile$/"

--- a/.tekton/caching-openshift-e2e-tests.yaml
+++ b/.tekton/caching-openshift-e2e-tests.yaml
@@ -40,6 +40,11 @@ spec:
         description: 'The Helm version to install and use for deployments.'
         type: string
         default: "3.21.3"
+      - name: openshift-ci-tasks-revision
+        description: 'Pinned commit of openshift/konflux-tasks for ephemeral cluster tasks.'
+        type: string
+        # renovate: datasource=git-refs depName=https://github.com/openshift/konflux-tasks
+        default: 5fb29d2447b801ff050d0f4d4285615f8ca75f2f
     tasks:
       - name: test-metadata
         taskRef:
@@ -107,7 +112,7 @@ spec:
             - name: url
               value: https://github.com/openshift/konflux-tasks
             - name: revision
-              value: 5fb29d2447b801ff050d0f4d4285615f8ca75f2f
+              value: $(params.openshift-ci-tasks-revision)
             - name: pathInRepo
               value: tasks/provision-ephemeral-cluster/0.1/provision-ephemeral-cluster.yaml
         params:
@@ -178,7 +183,7 @@ spec:
             - name: url
               value: https://github.com/openshift/konflux-tasks
             - name: revision
-              value: 5fb29d2447b801ff050d0f4d4285615f8ca75f2f
+              value: $(params.openshift-ci-tasks-revision)
             - name: pathInRepo
               value: tasks/copy-secrets-to-ephemeral-cluster/0.1/copy-secrets-to-ephemeral-cluster.yaml
         params:
@@ -360,7 +365,7 @@ spec:
             - name: url
               value: https://github.com/openshift/konflux-tasks
             - name: revision
-              value: 5fb29d2447b801ff050d0f4d4285615f8ca75f2f
+              value: $(params.openshift-ci-tasks-revision)
             - name: pathInRepo
               value: tasks/deprovision-ephemeral-cluster/0.1/deprovision-ephemeral-cluster.yaml
         params:


### PR DESCRIPTION
Extract the pinned openshift/konflux-tasks commit SHA into a pipeline param so Renovate can track and update it automatically when new commits land on main.

Assisted-by: Claude claude-opus-4-6

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [x] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
