### PR TITLE
feat(KFLUXVNGD-1142): Add separate namespace configuration for squid and nginx

### DIFF
--- a/caching/values.schema.json
+++ b/caching/values.schema.json
@@ -630,6 +630,12 @@
         "name": {
           "type": "string",
           "description": "Name used for all squid resources and labels"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Namespace where squid will be deployed. Leave empty to use shared namespace.name for backward compatibility.",
+          "maxLength": 63,
+          "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
         }
       },
       "required": ["enabled", "name"],
@@ -646,6 +652,12 @@
         "name": {
           "type": "string",
           "description": "Name used for all nginx resources and labels"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Namespace where nginx will be deployed. Leave empty to use shared namespace.name for backward compatibility.",
+          "maxLength": 63,
+          "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
         },
         "replicaCount": {
           "type": "integer",

--- a/caching/values.yaml
+++ b/caching/values.yaml
@@ -79,6 +79,10 @@ squid:
   enabled: true
   # Name used for all squid resources (services, statefulset, configmap) and labels.
   name: "squid"
+  # Namespace where squid will be deployed.
+  # For new independent deployments, set to "squid-proxy".
+  # For backward compatibility with existing deployments, leave empty to use the shared namespace.name below.
+  namespace: ""
 
 # This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
 replicaCount: 1
@@ -273,9 +277,21 @@ tolerations: []
 # Uncomment the affinity section below to customize or disable these defaults
 # affinity: {}
 
-# IMPORTANT: This chart creates and manages its own namespace via templates/namespace.yaml
-# DO NOT use `helm install --namespace` or `helm upgrade --namespace` with this chart
-# All resources will be deployed to the namespace specified below
+# ============================================================================
+# BACKWARD COMPATIBILITY - Legacy namespace configuration
+# ============================================================================
+# This section is for backward compatibility with existing deployments that use
+# a single shared namespace. New deployments should use component-specific
+# namespaces (squid.namespace, nginx.namespace).
+#
+# IMPORTANT: When using legacy mode (namespace.name defined, component namespaces empty):
+# - This chart creates and manages its own namespace via templates/namespace.yaml
+# - DO NOT use `helm install --namespace` or `helm upgrade --namespace`
+# - All resources will be deployed to the namespace specified below
+#
+# When using component-specific namespaces:
+# - Set squid.namespace and/or nginx.namespace above
+# - templates/namespace.yaml will still render but is harmless (creates legacy namespace)
 namespace:
   name: caching
   annotations: {}
@@ -433,6 +449,11 @@ nginx:
 
   # Name used for all nginx resources (services, statefulset, configmap) and labels.
   name: "nginx"
+
+  # Namespace where nginx will be deployed.
+  # For new independent deployments, set to "nginx-proxy".
+  # For backward compatibility with existing deployments, leave empty to use the shared namespace.name below.
+  namespace: ""
 
   # Replica count for the nginx proxy StatefulSet
   replicaCount: 1


### PR DESCRIPTION
This is **Phase 1** of the namespace separation implementation - adds configuration fields only. Template wiring and runtime functionality will be implemented in follow-up PRs tracked under epic [KFLUXVNGD-827](https://redhat.atlassian.net/browse/KFLUXVNGD-827).

Changes: 
- Add squid.namespace field with empty default (for backward compatibility)
- Add nginx.namespace field with empty default (for backward compatibility)
- Update namespace section comments to explain legacy vs new deployment modes
- Update values.schema.json to allow new namespace properties

Jira-Url: https://redhat.atlassian.net/browse/KFLUXVNGD-1142
Co-Authored-By: Claude Sonnet 4.5

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [ ] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?


[KFLUXVNGD-827]: https://redhat.atlassian.net/browse/KFLUXVNGD-827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ