### PR TITLE
feat(KFLUXVNGD-1143): Add namespace helper functions to _helpers.tpl

### DIFF
--- a/caching/templates/_helpers.tpl
+++ b/caching/templates/_helpers.tpl
@@ -20,6 +20,41 @@ Get current environment - defaults to "release" if not set
 
 {{/*
 =============================================================================
+NAMESPACE HELPERS
+=============================================================================
+*/}}
+
+{{/*
+Internal helper for namespace resolution with fallback chain
+Returns component-specific namespace if set, falls back to namespace.name, defaults to "caching"
+*/}}
+{{- define "caching.component.namespace" -}}
+{{- $componentNs := .componentNs -}}
+{{- if $componentNs -}}
+  {{- $componentNs -}}
+{{- else if .ctx.Values.namespace.name -}}
+  {{- .ctx.Values.namespace.name -}}
+{{- else -}}
+  caching
+{{- end -}}
+{{- end }}
+
+{{/*
+Determine namespace for Squid component
+*/}}
+{{- define "caching.squid.namespace" -}}
+{{- include "caching.component.namespace" (dict "componentNs" .Values.squid.namespace "ctx" .) -}}
+{{- end }}
+
+{{/*
+Determine namespace for Nginx component
+*/}}
+{{- define "caching.nginx.namespace" -}}
+{{- include "caching.component.namespace" (dict "componentNs" .Values.nginx.namespace "ctx" .) -}}
+{{- end }}
+
+{{/*
+=============================================================================
 SQUID COMPONENT HELPERS
 =============================================================================
 */}}


### PR DESCRIPTION
Add caching.squid.namespace and caching.nginx.namespace helper functions to determine which namespace to use for each component. These helpers support both legacy deployments (using shared namespace.name) and new independent deployments (using component-specific namespaces).

The helpers implement the following priority:
1. Use component-specific namespace if set (squid.namespace/nginx.namespace)
2. Fall back to shared namespace.name if component namespace is empty
3. Default to "caching" if both are unset

Jira-Url: https://redhat.atlassian.net/browse/KFLUXVNGD-1143
Assisted-By: Claude Code

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [ ] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
