### PR TITLE
Remove optional cluster deprovision finally task

### DIFF
--- a/.tekton/caching-openshift-e2e-tests.yaml
+++ b/.tekton/caching-openshift-e2e-tests.yaml
@@ -356,20 +356,3 @@ spec:
                 oc logs -n caching caching-test --tail=2000 2>&1 || true
 
                 echo "All E2E tests passed!"
-
-    finally:
-      - name: deprovision-ephemeral-cluster
-        taskRef:
-          resolver: git
-          params:
-            - name: url
-              value: https://github.com/openshift/konflux-tasks
-            - name: revision
-              value: $(params.openshift-ci-tasks-revision)
-            - name: pathInRepo
-              value: tasks/deprovision-ephemeral-cluster/0.1/deprovision-ephemeral-cluster.yaml
-        params:
-          - name: testPlatformClusterClaimName
-            value: $(tasks.provision-cluster.results.testPlatformClusterClaimName)
-          - name: testPlatformClusterClaimNamespace
-            value: $(tasks.provision-cluster.results.testPlatformClusterClaimNamespace)


### PR DESCRIPTION
Cluster teardown is now performed automatically upon deletion of the TestPlatformCluster claim and its remote EphemeralCluster resource. This can significantly reduce the execution time of the pipeline. See https://github.com/openshift/ci-tools/pull/5332.

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [x] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
