### PR TITLE
feat(KFLUXVNGD-1144): Update squid templates to use namespace helper

### DIFF
--- a/caching/templates/configmap.yaml
+++ b/caching/templates/configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Values.squid.name }}-config
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ include "caching.squid.namespace" . }}
   labels:
     {{- include "caching.squid.labels" . | nindent 4 }}
 data:

--- a/caching/templates/deployment.yaml
+++ b/caching/templates/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ .Values.squid.name }}
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ include "caching.squid.namespace" . }}
   labels:
     {{- include "caching.squid.labels" . | nindent 4 }}
 spec:
@@ -195,7 +195,7 @@ spec:
         # Mount the secret created by cert-manager
         - name: squid-certs-secret
           secret:
-            secretName: {{ .Values.namespace.name }}-tls
+            secretName: {{ include "caching.squid.namespace" . }}-tls
         # Volume for Squid's SSL database
         - name: squid-spool-ssl
           emptyDir: {}

--- a/caching/templates/headless-service.yaml
+++ b/caching/templates/headless-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.squid.name }}-headless
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ include "caching.squid.namespace" . }}
   labels:
     {{- include "caching.squid.labels" . | nindent 4 }}
 spec:

--- a/caching/templates/https-test-server-bundle.yaml
+++ b/caching/templates/https-test-server-bundle.yaml
@@ -1,9 +1,9 @@
-{{- if .Values.test.enabled }}
+{{- if and .Values.squid.enabled .Values.test.enabled }}
 apiVersion: trust.cert-manager.io/v1alpha1
 kind: Bundle
 metadata:
   name: test-server-bundle
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ include "caching.squid.namespace" . }}
 spec:
   sources:
   - secret:

--- a/caching/templates/mirrord-target-pod.yaml
+++ b/caching/templates/mirrord-target-pod.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ .Values.mirrord.targetPod.name }}
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ include "caching.squid.namespace" . }}
   labels:
     # Use different app name to avoid service selector conflicts
     app.kubernetes.io/name: mirrord-target

--- a/caching/templates/proxy-certificate.yaml
+++ b/caching/templates/proxy-certificate.yaml
@@ -1,9 +1,9 @@
-{{- if (index .Values "selfsigned-certificate").enabled }}
+{{- if and .Values.squid.enabled (index .Values "selfsigned-certificate").enabled }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ .Values.namespace.name }}-cert
-  namespace: {{ .Values.namespace.name }}
+  name: {{ include "caching.squid.namespace" . }}-cert
+  namespace: {{ include "caching.squid.namespace" . }}
 spec:
   isCA: true
   duration: 2160h # 90 days
@@ -14,11 +14,11 @@ spec:
   dnsNames:
   - localhost
   - {{ .Values.squid.name }}
-  - {{ .Values.squid.name }}.{{ .Values.namespace.name }}.svc
-  - {{ .Values.squid.name }}.{{ .Values.namespace.name }}.svc.cluster.local
+  - {{ .Values.squid.name }}.{{ include "caching.squid.namespace" . }}.svc
+  - {{ .Values.squid.name }}.{{ include "caching.squid.namespace" . }}.svc.cluster.local
 
   issuerRef:
     kind: ClusterIssuer
-    name: {{ .Values.namespace.name }}-ca-issuer
-  secretName: {{ .Values.namespace.name }}-tls
+    name: {{ include "caching.squid.namespace" . }}-ca-issuer
+  secretName: {{ include "caching.squid.namespace" . }}-tls
 {{- end }}

--- a/caching/templates/self-signed-cluster-issuer.yaml
+++ b/caching/templates/self-signed-cluster-issuer.yaml
@@ -1,8 +1,8 @@
-{{- if (index .Values "selfsigned-certificate").enabled }}
+{{- if and .Values.squid.enabled (index .Values "selfsigned-certificate").enabled }}
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: {{ .Values.namespace.name }}-self-signed-cluster-issuer
+  name: {{ include "caching.squid.namespace" . }}-self-signed-cluster-issuer
   labels:
     {{- include "caching.squid.labels" . | nindent 4 }}
 spec:
@@ -11,13 +11,13 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ .Values.namespace.name }}-self-signed-ca
+  name: {{ include "caching.squid.namespace" . }}-self-signed-ca
   namespace: {{ (index .Values "cert-manager").namespace }}
   labels:
     {{- include "caching.squid.labels" . | nindent 4 }}
 spec:
-  secretName: {{ .Values.namespace.name }}-root-ca-secret
-  commonName: {{ .Values.namespace.name }}-self-signed-ca
+  secretName: {{ include "caching.squid.namespace" . }}-root-ca-secret
+  commonName: {{ include "caching.squid.namespace" . }}-self-signed-ca
   duration: 43800h # 5 years
   renewBefore: 2160h # 90 days
   isCA: true
@@ -25,17 +25,17 @@ spec:
     algorithm: ECDSA
     size: 256
   issuerRef:
-    name: {{ .Values.namespace.name }}-self-signed-cluster-issuer
+    name: {{ include "caching.squid.namespace" . }}-self-signed-cluster-issuer
     kind: ClusterIssuer
     group: cert-manager.io
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
-  name: {{ .Values.namespace.name }}-ca-issuer
+  name: {{ include "caching.squid.namespace" . }}-ca-issuer
   labels:
     {{- include "caching.squid.labels" . | nindent 4 }}
 spec:
   ca:
-    secretName: {{ .Values.namespace.name }}-root-ca-secret
+    secretName: {{ include "caching.squid.namespace" . }}-root-ca-secret
 {{- end }}

--- a/caching/templates/service.yaml
+++ b/caching/templates/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.squid.name }}
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ include "caching.squid.namespace" . }}
   labels:
     {{- include "caching.squid.labels" . | nindent 4 }}
   {{- if .Values.squidExporter.enabled }}

--- a/caching/templates/serviceaccount.yaml
+++ b/caching/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "caching.squid.serviceAccountName" . }}
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ include "caching.squid.namespace" . }}
   labels:
     {{- include "caching.squid.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/caching/templates/servicemonitor.yaml
+++ b/caching/templates/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ .Values.squid.name }}
-  namespace: {{ .Values.prometheus.serviceMonitor.namespace | default .Values.namespace.name }}
+  namespace: {{ .Values.prometheus.serviceMonitor.namespace | default (include "caching.squid.namespace" .) }}
   labels:
     {{- include "caching.squid.labels" . | nindent 4 }}
     {{- with .Values.prometheus.serviceMonitor.labels }}
@@ -19,7 +19,7 @@ spec:
       {{- include "caching.squid.selectorLabels" . | nindent 6 }}
   namespaceSelector:
     matchNames:
-      - {{ .Values.namespace.name }}
+      - {{ include "caching.squid.namespace" . }}
   endpoints:
     - port: metrics
       path: {{ .Values.prometheus.serviceMonitor.path }}
@@ -40,7 +40,7 @@ spec:
       {{- if .Values.prometheus.serviceMonitor.perSiteTLS.enabled }}
       tlsConfig:
         {{- $clusterDomain := (default "cluster.local" .Values.clusterDomain) }}
-        {{- $svcFQDN := printf "%s.%s.svc.%s" .Values.squid.name .Values.namespace.name $clusterDomain }}
+        {{- $svcFQDN := printf "%s.%s.svc.%s" .Values.squid.name (include "caching.squid.namespace" .) $clusterDomain }}
         serverName: {{ .Values.prometheus.serviceMonitor.perSiteTLS.serverName | default $svcFQDN }}
         insecureSkipVerify: {{ .Values.prometheus.serviceMonitor.perSiteTLS.insecureSkipVerify | default false }}
         {{- with .Values.prometheus.serviceMonitor.perSiteTLS.ca }}

--- a/caching/templates/trust-manager-bundle.yaml
+++ b/caching/templates/trust-manager-bundle.yaml
@@ -1,14 +1,14 @@
-{{- if (index .Values "selfsigned-bundle").enabled }}
+{{- if and .Values.squid.enabled (index .Values "selfsigned-bundle").enabled }}
 apiVersion: trust.cert-manager.io/v1alpha1
 kind: Bundle
 metadata:
-  name: {{ .Values.namespace.name }}-ca-bundle
+  name: {{ include "caching.squid.namespace" . }}-ca-bundle
   labels:
     {{- include "caching.squid.labels" . | nindent 4 }}
 spec:
   sources:
   - secret:
-      name: "{{ .Values.namespace.name }}-root-ca-secret"
+      name: "{{ include "caching.squid.namespace" . }}-root-ca-secret"
       key: "ca.crt"
   target:
     configMap:


### PR DESCRIPTION
Replace all direct .Values.namespace.name references with {{ include "caching.squid.namespace" . }} in squid-related templates.

This enables squid to be deployed in an independent namespace while maintaining backward compatibility with legacy deployments.

Jira-Url: https://redhat.atlassian.net/browse/KFLUXVNGD-1144
Assisted-By: Claude Code

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [ ] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
