### PR TITLE
feat(KFLUXVNGD-1145): Update nginx templates to use namespace helper

### DIFF
--- a/caching/templates/namespace.yaml
+++ b/caching/templates/namespace.yaml
@@ -1,10 +1,18 @@
+{{- $baseNamespace := .Values.namespace.name }}
+{{- $baseAnnotations := .Values.namespace.annotations | default dict }}
+{{- $squidUsesBase := and .Values.squid.enabled (not .Values.squid.namespace) }}
+{{- $nginxUsesBase := and .Values.nginx.enabled (not .Values.nginx.namespace) }}
+{{- $testUsesBase := .Values.test.enabled }}
+{{- if or $squidUsesBase $nginxUsesBase $testUsesBase }}
+---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ .Values.namespace.name }}
+  name: {{ $baseNamespace }}
   labels:
-    name: {{ .Values.namespace.name }}
-{{- if .Values.namespace.annotations }}
+    name: {{ $baseNamespace }}
+{{- with $baseAnnotations }}
   annotations:
-{{ toYaml .Values.namespace.annotations | indent 4 }}
-{{- end }} 
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/caching/templates/nginx-configmap.yaml
+++ b/caching/templates/nginx-configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Values.nginx.name }}-config
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ include "caching.nginx.namespace" . }}
   labels:
     {{- include "caching.nginx.labels" . | nindent 4 }}
 data:
@@ -124,7 +124,10 @@ data:
             # DNS via the resolver directive. A static proxy_pass URL is only
             # resolved once at config load; using a variable enables re-resolution
             # based on the resolver's valid interval.
-            set $upstream_url "{{ .Values.nginx.upstream.url }}";
+            {{- $upstreamURL := .Values.nginx.upstream.url }}
+            {{- $upstreamParsed := urlParse $upstreamURL }}
+            set $upstream_url "{{ $upstreamURL }}";
+            set $upstream_host "{{ $upstreamParsed.host }}";
 
             # Health check endpoint for Kubernetes liveness/readiness probes.
             # Returns 200 OK without proxying the request or logging.
@@ -144,7 +147,7 @@ data:
                 proxy_pass $upstream_url;
 
                 # Send the upstream hostname so the backend receives the correct Host header
-                proxy_set_header Host {{ (urlParse $.Values.nginx.upstream.url).host }};
+                proxy_set_header Host $upstream_host;
                 proxy_set_header X-Real-IP $remote_addr;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
                 proxy_set_header X-Forwarded-Proto $scheme;
@@ -202,7 +205,7 @@ data:
             # Redirects are passed through as-is (not intercepted).
             location / {
                 proxy_pass $upstream_url;
-                proxy_set_header Host {{ (urlParse .Values.nginx.upstream.url).host }};
+                proxy_set_header Host $upstream_host;
                 proxy_set_header X-Real-IP $remote_addr;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
                 proxy_set_header X-Forwarded-Proto $scheme;

--- a/caching/templates/nginx-exporter-configmap.yaml
+++ b/caching/templates/nginx-exporter-configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Values.nginx.name }}-exporter-config
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ include "caching.nginx.namespace" . }}
   labels:
     {{- include "caching.nginx.labels" . | nindent 4 }}
 data:

--- a/caching/templates/nginx-headless-service.yaml
+++ b/caching/templates/nginx-headless-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.nginx.name }}-headless
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ include "caching.nginx.namespace" . }}
   labels:
     {{- include "caching.nginx.labels" . | nindent 4 }}
 spec:

--- a/caching/templates/nginx-namespace.yaml
+++ b/caching/templates/nginx-namespace.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.nginx.enabled .Values.nginx.namespace }}
+{{- $baseAnnotations := .Values.namespace.annotations | default dict }}
+{{- $nginxNs := include "caching.nginx.namespace" . }}
+{{- $isExplicitNull := kindIs "invalid" .Values.nginx.namespaceAnnotations }}
+{{- $nginxAnnotations := dict }}
+{{- if not $isExplicitNull }}
+{{- if .Values.nginx.namespaceAnnotations }}
+{{- $nginxAnnotations = .Values.nginx.namespaceAnnotations }}
+{{- else }}
+{{- $nginxAnnotations = $baseAnnotations }}
+{{- end }}
+{{- end }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ $nginxNs }}
+  labels:
+    name: {{ $nginxNs }}
+{{- with $nginxAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/caching/templates/nginx-service.yaml
+++ b/caching/templates/nginx-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.nginx.name }}
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ include "caching.nginx.namespace" . }}
   labels:
     {{- include "caching.nginx.labels" . | nindent 4 }}
   {{- with .Values.nginx.service.annotations }}

--- a/caching/templates/nginx-servicemonitor.yaml
+++ b/caching/templates/nginx-servicemonitor.yaml
@@ -1,9 +1,10 @@
 {{- if and .Values.nginx.enabled .Values.prometheus.serviceMonitor.enabled }}
+{{- $nginxNamespace := include "caching.nginx.namespace" . }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ .Values.nginx.name }}
-  namespace: {{ .Values.prometheus.serviceMonitor.namespace | default .Values.namespace.name }}
+  namespace: {{ .Values.prometheus.serviceMonitor.namespace | default $nginxNamespace }}
   labels:
     {{- include "caching.nginx.labels" . | nindent 4 }}
     {{- with .Values.prometheus.serviceMonitor.labels }}
@@ -19,7 +20,7 @@ spec:
       {{- include "caching.nginx.selectorLabels" . | nindent 6 }}
   namespaceSelector:
     matchNames:
-      - {{ .Values.namespace.name }}
+      - {{ $nginxNamespace }}
   endpoints:
     - port: metrics
       path: {{ .Values.prometheus.serviceMonitor.path }}
@@ -34,7 +35,7 @@ spec:
       {{- if .Values.nginx.tls.enabled }}
       tlsConfig:
         {{- $clusterDomain := (default "cluster.local" .Values.clusterDomain) }}
-        {{- $svcFQDN := printf "%s.%s.svc.%s" .Values.nginx.name .Values.namespace.name $clusterDomain }}
+        {{- $svcFQDN := printf "%s.%s.svc.%s" .Values.nginx.name $nginxNamespace $clusterDomain }}
         serverName: {{ .Values.prometheus.serviceMonitor.nginxTLS.serverName | default $svcFQDN }}
         insecureSkipVerify: {{ .Values.prometheus.serviceMonitor.nginxTLS.insecureSkipVerify | default false }}
         {{- with .Values.prometheus.serviceMonitor.nginxTLS.ca }}

--- a/caching/templates/nginx-statefulset.yaml
+++ b/caching/templates/nginx-statefulset.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ .Values.nginx.name }}
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ include "caching.nginx.namespace" . }}
   labels:
     {{- include "caching.nginx.labels" . | nindent 4 }}
 spec:

--- a/caching/templates/nginx-test-backend.yaml
+++ b/caching/templates/nginx-test-backend.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-test-backend
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ include "caching.nginx.namespace" . }}
   labels:
     app: nginx-test-backend
 spec:
@@ -68,7 +68,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: nginx-test-backend
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ include "caching.nginx.namespace" . }}
   labels:
     app: nginx-test-backend
 spec:

--- a/caching/templates/squid-namespace.yaml
+++ b/caching/templates/squid-namespace.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.squid.enabled .Values.squid.namespace }}
+{{- $baseAnnotations := .Values.namespace.annotations | default dict }}
+{{- $squidNs := include "caching.squid.namespace" . }}
+{{- $isExplicitNull := kindIs "invalid" .Values.squid.namespaceAnnotations }}
+{{- $squidAnnotations := dict }}
+{{- if not $isExplicitNull }}
+{{- if .Values.squid.namespaceAnnotations }}
+{{- $squidAnnotations = .Values.squid.namespaceAnnotations }}
+{{- else }}
+{{- $squidAnnotations = $baseAnnotations }}
+{{- end }}
+{{- end }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ $squidNs }}
+  labels:
+    name: {{ $squidNs }}
+{{- with $squidAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/caching/values.schema.json
+++ b/caching/values.schema.json
@@ -636,6 +636,13 @@
           "description": "Namespace where squid will be deployed. Leave empty to use shared namespace.name for backward compatibility.",
           "maxLength": 63,
           "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+        },
+        "namespaceAnnotations": {
+          "type": ["object", "null"],
+          "description": "Annotations to apply to the squid namespace when squid.namespace is set. If empty, falls back to namespace.annotations. Set to null to explicitly opt out.",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "required": ["enabled", "name"],
@@ -658,6 +665,13 @@
           "description": "Namespace where nginx will be deployed. Leave empty to use shared namespace.name for backward compatibility.",
           "maxLength": 63,
           "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+        },
+        "namespaceAnnotations": {
+          "type": ["object", "null"],
+          "description": "Annotations to apply to the nginx namespace when nginx.namespace is set. If empty, falls back to namespace.annotations. Set to null to explicitly opt out.",
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "replicaCount": {
           "type": "integer",

--- a/caching/values.yaml
+++ b/caching/values.yaml
@@ -83,6 +83,10 @@ squid:
   # For new independent deployments, set to "squid-proxy".
   # For backward compatibility with existing deployments, leave empty to use the shared namespace.name below.
   namespace: ""
+  # Annotations to apply to the squid namespace when squid.namespace is set.
+  # If empty ({}), falls back to namespace.annotations below.
+  # Set to null to explicitly opt out of annotations (no annotations on squid namespace).
+  namespaceAnnotations: {}
 
 # This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
 replicaCount: 1
@@ -454,6 +458,10 @@ nginx:
   # For new independent deployments, set to "nginx-proxy".
   # For backward compatibility with existing deployments, leave empty to use the shared namespace.name below.
   namespace: ""
+  # Annotations to apply to the nginx namespace when nginx.namespace is set.
+  # If empty ({}), falls back to namespace.annotations below.
+  # Set to null to explicitly opt out of annotations (no annotations on nginx namespace).
+  namespaceAnnotations: {}
 
   # Replica count for the nginx proxy StatefulSet
   replicaCount: 1

--- a/tests/helm/nginx_template_test.go
+++ b/tests/helm/nginx_template_test.go
@@ -471,7 +471,11 @@ var _ = Describe("Helm Template Nginx Configuration", func() {
 
 	Describe("Nginx ConfigMap Upstream Configuration", func() {
 		It("should configure upstream URL in all locations via variable for DNS re-resolution", func() {
+			testEnabled := false
 			output, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{
+				Test: &testhelpers.TestValues{
+					Enabled: &testEnabled,
+				},
 				Nginx: &testhelpers.NginxValues{
 					Enabled: true,
 					Upstream: &testhelpers.NginxUpstreamValues{
@@ -486,12 +490,13 @@ var _ = Describe("Helm Template Nginx Configuration", func() {
 
 			configMap := extractNginxConfigMapSection(output)
 
-			// Upstream URL should be set via variable once at server level
+			// Upstream URL and host should be set via variables once at server level
 			Expect(strings.Count(configMap, `set $upstream_url "http://nexus.example.com:8081"`)).To(Equal(1), "Should set upstream_url variable once at server level")
+			Expect(strings.Count(configMap, `set $upstream_host "nexus.example.com:8081"`)).To(Equal(1), "Should set upstream_host variable once at server level")
 			Expect(strings.Count(configMap, "proxy_pass $upstream_url")).To(Equal(2), "Should use upstream_url variable in proxy_pass in both locations")
 
-			// Host header should be derived from the upstream URL
-			Expect(strings.Count(configMap, "proxy_set_header Host nexus.example.com:8081")).To(Equal(2), "Should derive Host header from upstream URL in both locations")
+			// Host header should use the upstream_host variable
+			Expect(strings.Count(configMap, "proxy_set_header Host $upstream_host")).To(Equal(2), "Should use upstream_host variable in Host header in both locations")
 		})
 
 		It("should use default proxy_read_timeout when not specified", func() {
@@ -792,5 +797,89 @@ var _ = Describe("Helm Template Nginx Configuration", func() {
 			Expect(configMap).To(ContainSubstring("name: my-custom-proxy-config"), "ConfigMap should use custom name with -config suffix")
 		})
 
+	})
+
+	Describe("Nginx Namespace Configuration", func() {
+		It("should create nginx namespace when nginx.namespace is set", func() {
+			output, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{
+				Nginx: &testhelpers.NginxValues{
+					Enabled:   true,
+					Namespace: "nginx-proxy",
+					Upstream: &testhelpers.NginxUpstreamValues{
+						URL: "http://backend:8080",
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Should create nginx-proxy namespace
+			Expect(output).To(ContainSubstring("kind: Namespace"))
+			Expect(output).To(MatchRegexp(`(?s)kind: Namespace.*?name: nginx-proxy`), "Should create nginx-proxy namespace")
+		})
+
+		It("should deploy nginx resources to custom namespace", func() {
+			output, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{
+				Nginx: &testhelpers.NginxValues{
+					Enabled:   true,
+					Namespace: "nginx-proxy",
+					Upstream: &testhelpers.NginxUpstreamValues{
+						URL: "http://backend:8080",
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// All nginx resources should be in nginx-proxy namespace
+			statefulSet := extractNginxStatefulSetSection(output)
+			Expect(statefulSet).To(ContainSubstring("namespace: nginx-proxy"), "StatefulSet should be in nginx-proxy namespace")
+
+			service := extractNginxServiceSection(output)
+			Expect(service).To(ContainSubstring("namespace: nginx-proxy"), "Service should be in nginx-proxy namespace")
+
+			configMap := extractNginxConfigMapSection(output)
+			Expect(configMap).To(ContainSubstring("namespace: nginx-proxy"), "ConfigMap should be in nginx-proxy namespace")
+		})
+
+		It("should use default caching namespace when nginx.namespace is empty", func() {
+			output, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{
+				Nginx: &testhelpers.NginxValues{
+					Enabled: true,
+					Upstream: &testhelpers.NginxUpstreamValues{
+						URL: "http://backend:8080",
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// All nginx resources should be in default caching namespace
+			statefulSet := extractNginxStatefulSetSection(output)
+			Expect(statefulSet).To(ContainSubstring("namespace: caching"), "StatefulSet should be in caching namespace")
+
+			service := extractNginxServiceSection(output)
+			Expect(service).To(ContainSubstring("namespace: caching"), "Service should be in caching namespace")
+		})
+
+		It("should use correct namespace in test backend URL when nginx has custom namespace", func() {
+			testEnabled := true
+			output, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{
+				Test: &testhelpers.TestValues{
+					Enabled: &testEnabled,
+				},
+				Nginx: &testhelpers.NginxValues{
+					Enabled:   true,
+					Namespace: "nginx-proxy",
+					Upstream: &testhelpers.NginxUpstreamValues{
+						URL: "http://nginx-test-backend.nginx-proxy.svc.cluster.local:9090",
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			configMap := extractNginxConfigMapSection(output)
+
+			// Test backend URL should use nginx's custom namespace
+			Expect(configMap).To(ContainSubstring(`set $upstream_url "http://nginx-test-backend.nginx-proxy.svc.cluster.local:9090"`), "Test backend URL should use nginx's custom namespace")
+			Expect(configMap).To(ContainSubstring(`set $upstream_host "nginx-test-backend.nginx-proxy.svc.cluster.local:9090"`), "Upstream host should match test backend in custom namespace")
+		})
 	})
 })

--- a/tests/testhelpers/nginx_helpers.go
+++ b/tests/testhelpers/nginx_helpers.go
@@ -20,6 +20,7 @@ type NginxValues struct {
 	// Enabled must NOT have omitempty since we need to explicitly set false to disable
 	Enabled      bool                  `json:"enabled"`
 	Name         string                `json:"name,omitempty"`
+	Namespace    string                `json:"namespace,omitempty"`
 	ReplicaCount int                   `json:"replicaCount,omitempty"`
 	TLS          *NginxTLSValues       `json:"tls,omitempty"`
 	Upstream     *NginxUpstreamValues  `json:"upstream,omitempty"`

--- a/tests/testhelpers/proxy_test_helpers.go
+++ b/tests/testhelpers/proxy_test_helpers.go
@@ -411,6 +411,12 @@ type SquidHelmValues struct {
 	Nginx              *NginxValues              `json:"nginx,omitempty"`
 	Service            *ServiceValues            `json:"service,omitempty"`
 	Prometheus         *PrometheusValues         `json:"prometheus,omitempty"`
+	Test               *TestValues               `json:"test,omitempty"`
+}
+
+// TestValues holds test configuration
+type TestValues struct {
+	Enabled *bool `json:"enabled,omitempty"`
 }
 
 // SquidExporterValues holds squid-exporter configuration


### PR DESCRIPTION
Replace all direct .Values.namespace.name references with {{ include "caching.nginx.namespace" . }} in nginx-related templates.

This enables nginx to be deployed in an independent namespace while maintaining backward compatibility with legacy deployments.

Jira-Url: https://redhat.atlassian.net/browse/KFLUXVNGD-1145
Assisted-By: Claude Code

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [x] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
