### PR TITLE
feat(KFLUXVNGD-1147): squid namespace in test templates

### DIFF
--- a/caching/templates/https-test-server-selfsigned-issuer.yaml
+++ b/caching/templates/https-test-server-selfsigned-issuer.yaml
@@ -35,17 +35,17 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: test-server-cert
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ include "caching.squid.namespace" . }}
 spec:
   secretName: test-server-tls
   duration: 2160h # 90d
   renewBefore: 360h # 15d
-  commonName: test-server.{{ .Values.namespace.name }}.svc.cluster.local
+  commonName: test-server.{{ include "caching.squid.namespace" . }}.svc.cluster.local
   dnsNames:
   - test-server
-  - test-server.{{ .Values.namespace.name }}
-  - test-server.{{ .Values.namespace.name }}.svc
-  - test-server.{{ .Values.namespace.name }}.svc.cluster.local
+  - test-server.{{ include "caching.squid.namespace" . }}
+  - test-server.{{ include "caching.squid.namespace" . }}.svc
+  - test-server.{{ include "caching.squid.namespace" . }}.svc.cluster.local
   issuerRef:
     name: test-server-ca-issuer
     kind: ClusterIssuer

--- a/caching/templates/https-test-server.yaml
+++ b/caching/templates/https-test-server.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: test-server
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ include "caching.squid.namespace" . }}
   labels:
     app: test-server
 spec:
@@ -54,7 +54,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: test-server
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ include "caching.squid.namespace" . }}
 spec:
   selector:
     app: test-server
@@ -67,13 +67,13 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: test-server-nginx-conf
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ include "caching.squid.namespace" . }}
 data:
   default.conf: |
     # Listen on 8443 (non-privileged port) for OpenShift compatibility
     server {
         listen 8443 ssl;
-        server_name test-server.{{ .Values.namespace.name }}.svc.cluster.local;
+        server_name test-server.{{ include "caching.squid.namespace" . }}.svc.cluster.local;
 
         ssl_certificate /etc/nginx/tls/tls.crt;
         ssl_certificate_key /etc/nginx/tls/tls.key;

--- a/caching/templates/test-pod.yaml
+++ b/caching/templates/test-pod.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ .Values.test.name }}"
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ include "caching.squid.namespace" . }}
   labels:
     # Use different app names from the squid or nginx pods to avoid service selector conflicts
     app.kubernetes.io/name: {{ .Values.test.name }}
@@ -30,11 +30,11 @@ spec:
     - /app/test-entrypoint.sh
     env:
     - name: TARGET_NAMESPACE
-      value: {{ .Values.namespace.name | quote }}
+      value: {{ include "caching.squid.namespace" . | quote }}
     - name: SQUID_SERVICE
-      value: "{{ .Values.squid.name }}.{{ .Values.namespace.name }}.svc.cluster.local:{{ .Values.service.port }}"
+      value: "{{ .Values.squid.name }}.{{ include "caching.squid.namespace" . }}.svc.cluster.local:{{ .Values.service.port }}"
     - name: NGINX_SERVICE
-      value: "{{ .Values.nginx.name }}.{{ .Values.namespace.name }}.svc.cluster.local:{{ .Values.nginx.service.port }}"
+      value: "{{ .Values.nginx.name }}.{{ include "caching.nginx.namespace" . }}.svc.cluster.local:{{ .Values.nginx.service.port }}"
     - name: LABEL_FILTER
       value: {{ .Values.test.labelFilter | quote }}
     # Pass environment to test binary so it knows which image repos to use

--- a/caching/templates/test-rbac.yaml
+++ b/caching/templates/test-rbac.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.test.name }}
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ include "caching.squid.namespace" . }}
   labels:
     {{- include "caching.squid.labels" . | nindent 4 }}
     app.kubernetes.io/component: test
@@ -75,5 +75,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.test.name }}
-  namespace: {{ .Values.namespace.name }}
+  namespace: {{ include "caching.squid.namespace" . }}
 {{- end }}


### PR DESCRIPTION
Update squid SSL-bump test templates to use caching.squid.namespace and nginx FQDNs for split namespace installs


Assisted-by: Cursor

### Author's Checklist
- [ ] I understand the problem that the PR is trying to address.
- [ ] I understand the solution and its role and impact within the wider system.
- [ ] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
