### PR TITLE
Use FQDN format with namespace helpers for cross-namespace service references

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ This project uses hermetic (network-isolated) builds in Konflux CI. See [HERMETI
 # Same namespace
 curl --proxy http://squid:3128 http://httpbin.org/ip
 
-# Cross-namespace
-curl --proxy http://squid.caching.svc.cluster.local:3128 http://httpbin.org/ip
+# Cross-namespace (replace <NAMESPACE> with your deployment namespace, default: "caching")
+curl --proxy http://squid.<NAMESPACE>.svc.cluster.local:3128 http://httpbin.org/ip
 ```
 
 #### Testing with a curl Pod
@@ -77,11 +77,11 @@ curl --proxy http://squid.caching.svc.cluster.local:3128 http://httpbin.org/ip
 ```bash
 # Test HTTP proxy
 kubectl run test-curl --image=curlimages/curl:latest --rm -it -- \
-    sh -c 'curl --proxy http://squid.caching.svc.cluster.local:3128 http://httpbin.org/ip'
+    sh -c 'curl --proxy http://squid.<NAMESPACE>.svc.cluster.local:3128 http://httpbin.org/ip'
 
 # Test HTTPS via SSL-bump (-k to skip cert verification)
 kubectl run test-curl-ssl --image=curlimages/curl:latest --rm -it -- \
-    sh -c 'curl -k --proxy http://squid.caching.svc.cluster.local:3128 https://httpbin.org/ip'
+    sh -c 'curl -k --proxy http://squid.<NAMESPACE>.svc.cluster.local:3128 https://httpbin.org/ip'
 ```
 
 ### From Your Local Machine
@@ -118,6 +118,7 @@ helm install caching ./caching --set environment=dev --set nginx.enabled=true
 | `selfsigned-certificate.enabled` | `true` | Create certificate resources |
 | `squidExporter.enabled` | `true` | Enable Prometheus metrics |
 | `nginx.enabled` | `false` | Deploy NGINX reverse proxy |
+| `clusterDomain` | `""` (defaults to `cluster.local`) | Cluster DNS domain for FQDN generation |
 
 ## Testing
 

--- a/caching/templates/NOTES.txt
+++ b/caching/templates/NOTES.txt
@@ -1,17 +1,18 @@
-Your Squid proxy has been deployed to the '{{ .Values.namespace.name }}' namespace.
+{{- $squidNamespace := include "caching.squid.namespace" . -}}
+Your Squid proxy has been deployed to the '{{ $squidNamespace }}' namespace.
 
 To connect from other pods within the Kubernetes cluster:
-- From inside the '{{ .Values.namespace.name }}' namespace:
+- From inside the '{{ $squidNamespace }}' namespace:
   http://{{ .Values.squid.name }}:{{ .Values.service.port }}
 
 - From any namespace:
-  http://{{ .Values.squid.name }}.{{ .Values.namespace.name }}.svc.cluster.local:{{ .Values.service.port }}
+  http://{{ include "caching.squid.fqdn" . }}:{{ .Values.service.port }}
 
 
 For local testing, you can forward the service port to your machine:
 1. Get the pod name:
-   export POD_NAME=$(kubectl get pods --namespace {{ .Values.namespace.name }} -l "app.kubernetes.io/name={{ .Values.squid.name }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+   export POD_NAME=$(kubectl get pods --namespace {{ $squidNamespace }} -l "app.kubernetes.io/name={{ .Values.squid.name }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
 
 2. Forward the port:
    echo "Forwarding Squid proxy to http://127.0.0.1:3128"
-   kubectl --namespace {{ .Values.namespace.name }} port-forward $POD_NAME 3128:3128
+   kubectl --namespace {{ $squidNamespace }} port-forward $POD_NAME 3128:3128

--- a/caching/templates/_helpers.tpl
+++ b/caching/templates/_helpers.tpl
@@ -55,6 +55,38 @@ Determine namespace for Nginx component
 
 {{/*
 =============================================================================
+DNS / FQDN HELPERS
+=============================================================================
+*/}}
+
+{{/*
+Cluster DNS domain, defaulting to "cluster.local" when not set.
+*/}}
+{{- define "caching.clusterDomain" -}}
+{{- .Values.clusterDomain | default "cluster.local" | trimSuffix "." -}}
+{{- end }}
+
+{{/*
+Build a fully qualified domain name: <name>.<namespace>.svc.<clusterDomain>
+*/}}
+{{- define "caching.fqdn" -}}
+{{- printf "%s.%s.svc.%s" .name .namespace (include "caching.clusterDomain" .ctx) -}}
+{{- end }}
+
+{{- define "caching.squid.fqdn" -}}
+{{- include "caching.fqdn" (dict "name" .Values.squid.name "namespace" (include "caching.squid.namespace" .) "ctx" .) -}}
+{{- end }}
+
+{{- define "caching.nginx.fqdn" -}}
+{{- include "caching.fqdn" (dict "name" .Values.nginx.name "namespace" (include "caching.nginx.namespace" .) "ctx" .) -}}
+{{- end }}
+
+{{- define "caching.test-server.fqdn" -}}
+{{- include "caching.fqdn" (dict "name" "test-server" "namespace" (include "caching.squid.namespace" .) "ctx" .) -}}
+{{- end }}
+
+{{/*
+=============================================================================
 SQUID COMPONENT HELPERS
 =============================================================================
 */}}

--- a/caching/templates/https-test-server-selfsigned-issuer.yaml
+++ b/caching/templates/https-test-server-selfsigned-issuer.yaml
@@ -40,12 +40,12 @@ spec:
   secretName: test-server-tls
   duration: 2160h # 90d
   renewBefore: 360h # 15d
-  commonName: test-server.{{ include "caching.squid.namespace" . }}.svc.cluster.local
+  commonName: {{ include "caching.test-server.fqdn" . }}
   dnsNames:
   - test-server
   - test-server.{{ include "caching.squid.namespace" . }}
   - test-server.{{ include "caching.squid.namespace" . }}.svc
-  - test-server.{{ include "caching.squid.namespace" . }}.svc.cluster.local
+  - {{ include "caching.test-server.fqdn" . }}
   issuerRef:
     name: test-server-ca-issuer
     kind: ClusterIssuer

--- a/caching/templates/https-test-server.yaml
+++ b/caching/templates/https-test-server.yaml
@@ -73,7 +73,7 @@ data:
     # Listen on 8443 (non-privileged port) for OpenShift compatibility
     server {
         listen 8443 ssl;
-        server_name test-server.{{ include "caching.squid.namespace" . }}.svc.cluster.local;
+        server_name {{ include "caching.test-server.fqdn" . }};
 
         ssl_certificate /etc/nginx/tls/tls.crt;
         ssl_certificate_key /etc/nginx/tls/tls.key;

--- a/caching/templates/nginx-servicemonitor.yaml
+++ b/caching/templates/nginx-servicemonitor.yaml
@@ -34,8 +34,7 @@ spec:
       honorLabels: true
       {{- if .Values.nginx.tls.enabled }}
       tlsConfig:
-        {{- $clusterDomain := (default "cluster.local" .Values.clusterDomain) }}
-        {{- $svcFQDN := printf "%s.%s.svc.%s" .Values.nginx.name $nginxNamespace $clusterDomain }}
+        {{- $svcFQDN := include "caching.nginx.fqdn" . }}
         serverName: {{ .Values.prometheus.serviceMonitor.nginxTLS.serverName | default $svcFQDN }}
         insecureSkipVerify: {{ .Values.prometheus.serviceMonitor.nginxTLS.insecureSkipVerify | default false }}
         {{- with .Values.prometheus.serviceMonitor.nginxTLS.ca }}

--- a/caching/templates/proxy-certificate.yaml
+++ b/caching/templates/proxy-certificate.yaml
@@ -15,7 +15,7 @@ spec:
   - localhost
   - {{ .Values.squid.name }}
   - {{ .Values.squid.name }}.{{ include "caching.squid.namespace" . }}.svc
-  - {{ .Values.squid.name }}.{{ include "caching.squid.namespace" . }}.svc.cluster.local
+  - {{ include "caching.squid.fqdn" . }}
 
   issuerRef:
     kind: ClusterIssuer

--- a/caching/templates/servicemonitor.yaml
+++ b/caching/templates/servicemonitor.yaml
@@ -39,8 +39,7 @@ spec:
       honorLabels: true
       {{- if .Values.prometheus.serviceMonitor.perSiteTLS.enabled }}
       tlsConfig:
-        {{- $clusterDomain := (default "cluster.local" .Values.clusterDomain) }}
-        {{- $svcFQDN := printf "%s.%s.svc.%s" .Values.squid.name (include "caching.squid.namespace" .) $clusterDomain }}
+        {{- $svcFQDN := include "caching.squid.fqdn" . }}
         serverName: {{ .Values.prometheus.serviceMonitor.perSiteTLS.serverName | default $svcFQDN }}
         insecureSkipVerify: {{ .Values.prometheus.serviceMonitor.perSiteTLS.insecureSkipVerify | default false }}
         {{- with .Values.prometheus.serviceMonitor.perSiteTLS.ca }}

--- a/caching/templates/test-pod.yaml
+++ b/caching/templates/test-pod.yaml
@@ -32,9 +32,9 @@ spec:
     - name: TARGET_NAMESPACE
       value: {{ include "caching.squid.namespace" . | quote }}
     - name: SQUID_SERVICE
-      value: "{{ .Values.squid.name }}.{{ include "caching.squid.namespace" . }}.svc.cluster.local:{{ .Values.service.port }}"
+      value: "{{ include "caching.squid.fqdn" . }}:{{ .Values.service.port }}"
     - name: NGINX_SERVICE
-      value: "{{ .Values.nginx.name }}.{{ include "caching.nginx.namespace" . }}.svc.cluster.local:{{ .Values.nginx.service.port }}"
+      value: "{{ include "caching.nginx.fqdn" . }}:{{ .Values.nginx.service.port }}"
     - name: LABEL_FILTER
       value: {{ .Values.test.labelFilter | quote }}
     # Pass environment to test binary so it knows which image repos to use

--- a/docs/development.md
+++ b/docs/development.md
@@ -99,11 +99,11 @@ curl --proxy http://127.0.0.1:3128 http://httpbin.org/ip
 
 # From within the cluster (creates a temporary test pod)
 kubectl run test-curl --image=curlimages/curl:latest --rm -it -- \
-    sh -c 'curl --proxy http://squid.caching.svc.cluster.local:3128 http://httpbin.org/ip'
+    sh -c 'curl --proxy http://squid.<NAMESPACE>.svc.cluster.local:3128 http://httpbin.org/ip'
 
 # Test HTTPS via SSL-bump
 kubectl run test-curl-ssl --image=curlimages/curl:latest --rm -it -- \
-    sh -c 'curl -k --proxy http://squid.caching.svc.cluster.local:3128 https://httpbin.org/ip'
+    sh -c 'curl -k --proxy http://squid.<NAMESPACE>.svc.cluster.local:3128 https://httpbin.org/ip'
 ```
 
 ## Mage Command Reference

--- a/docs/monitoring-tests.md
+++ b/docs/monitoring-tests.md
@@ -238,7 +238,7 @@ kill $PF_PID 2>/dev/null || true
 ```bash
 # Create test pod and test proxy
 kubectl run test-client --image=curlimages/curl:latest --rm -it -- \
-  curl --proxy http://squid.caching.svc.cluster.local:3128 --connect-timeout 10 http://httpbin.org/ip
+  curl --proxy http://squid.<NAMESPACE>.svc.cluster.local:3128 --connect-timeout 10 http://httpbin.org/ip
 ```
 
 **Expected Result**: JSON response showing external IP, confirming proxy works from within cluster.

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -82,7 +82,7 @@ helm install caching ./caching --set prometheus.serviceMonitor.enabled=false
 scrape_configs:
   - job_name: 'squid-proxy'
     static_configs:
-      - targets: ['squid.caching.svc.cluster.local:9301']
+      - targets: ['squid.<NAMESPACE>.svc.<CLUSTER_DOMAIN>:9301']
     scrape_interval: 30s
     metrics_path: '/metrics'
 ```
@@ -139,10 +139,11 @@ The metrics are exposed on the service:
 
 ```bash
 # Standard squid-exporter metrics (from within the cluster)
-curl http://squid.caching.svc.cluster.local:9301/metrics
+# Replace <NAMESPACE> (default: "caching") and <CLUSTER_DOMAIN> (default: "cluster.local")
+curl http://squid.<NAMESPACE>.svc.<CLUSTER_DOMAIN>:9301/metrics
 
 # Per-site exporter metrics (from within the cluster — uses HTTPS)
-curl -k https://squid.caching.svc.cluster.local:9302/metrics
+curl -k https://squid.<NAMESPACE>.svc.<CLUSTER_DOMAIN>:9302/metrics
 ```
 
 ## Troubleshooting Metrics

--- a/docs/prometheus-config-example.yaml
+++ b/docs/prometheus-config-example.yaml
@@ -1,6 +1,9 @@
 # Example Prometheus configuration for scraping Squid metrics
 # This file shows how to configure Prometheus to scrape metrics from the Squid exporter
 # when not using Prometheus Operator
+#
+# Replace <NAMESPACE> with your deployment namespace (default: "caching")
+# Replace <CLUSTER_DOMAIN> with your cluster DNS domain (default: "cluster.local")
 
 # Add this job to your prometheus.yml configuration file
 global:
@@ -10,7 +13,7 @@ scrape_configs:
   # Squid Caching Metrics
   - job_name: 'squid-proxy'
     static_configs:
-      - targets: ['squid.{{ .Values.namespace.name }}.svc.cluster.local:9301']  # Adjust namespace if different
+      - targets: ['squid.<NAMESPACE>.svc.<CLUSTER_DOMAIN>:9301']
     scrape_interval: 30s
     scrape_timeout: 10s
     metrics_path: '/metrics'
@@ -23,11 +26,11 @@ scrape_configs:
       - source_labels: [__param_target]
         target_label: instance
       - target_label: __address__
-        replacement: squid.{{ .Values.namespace.name }}.svc.cluster.local:9301
+        replacement: squid.<NAMESPACE>.svc.<CLUSTER_DOMAIN>:9301
       - target_label: service
-        replacement: squid-{{ .Values.namespace.name }}
+        replacement: squid-<NAMESPACE>
       - target_label: component
-        replacement: {{ .Values.namespace.name }}
+        replacement: <NAMESPACE>
 
     # Optional: Filter metrics to only include squid-related ones
     metric_relabel_configs:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -144,7 +144,7 @@ kubectl get pods -n caching
 
 # Verify proxy connectivity manually
 kubectl run debug --image=curlimages/curl:latest --rm -it -- \
-  curl -v --proxy http://squid.caching.svc.cluster.local:3128 http://httpbin.org/ip
+  curl -v --proxy http://squid.<NAMESPACE>.svc.cluster.local:3128 http://httpbin.org/ip
 
 # View test logs from helm tests
 kubectl logs -n caching -l app.kubernetes.io/component=test
@@ -177,7 +177,7 @@ kubectl get pods -n caching
 kubectl logs -n caching statefulset/squid
 
 # Test connectivity from within cluster
-kubectl run debug --image=curlimages/curl:latest --rm -it -- curl -v --proxy http://squid.caching.svc.cluster.local:3128 http://httpbin.org/ip
+kubectl run debug --image=curlimages/curl:latest --rm -it -- curl -v --proxy http://squid.<NAMESPACE>.svc.cluster.local:3128 http://httpbin.org/ip
 
 # Check service endpoints
 kubectl get endpoints -n caching


### PR DESCRIPTION
Replace hardcoded cluster.local with configurable clusterDomain helper and use namespace helpers consistently across all templates. Add caching.fqdn helper to centralize FQDN construction for ServiceMonitor TLS config.

Jira-Url: https://redhat.atlassian.net/browse/KFLUXVNGD-1148
Co-Authored-By: Claude Opus 4.6

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [x] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
