### PR TITLE
ci: Vendor jetstack Helm charts into caching-tester for hermetic e2e

### DIFF
--- a/.tekton/caching-tester-pull-request.yaml
+++ b/.tekton/caching-tester-pull-request.yaml
@@ -36,7 +36,7 @@ spec:
   - name: hermetic
     value: "true"
   - name: prefetch-input
-    value: '[{"type": "gomod", "path": "."}, {"type": "rpm", "path": "."}]'
+    value: '[{"type": "gomod", "path": "."}, {"type": "rpm", "path": "."}, {"type": "generic", "path": "."}]'
   - name: enable-cache-proxy
     value: "true"
   pipelineSpec:

--- a/.tekton/caching-tester-push.yaml
+++ b/.tekton/caching-tester-push.yaml
@@ -32,7 +32,7 @@ spec:
   - name: hermetic
     value: "true"
   - name: prefetch-input
-    value: '[{"type": "gomod", "path": "."}, {"type": "rpm", "path": "."}]'
+    value: '[{"type": "gomod", "path": "."}, {"type": "rpm", "path": "."}, {"type": "generic", "path": "."}]'
   - name: enable-cache-proxy
     value: "true"
   pipelineSpec:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ Local and CI use dedicated checks; most are **not** run inside the devcontainer 
 All dependencies must be locked for network-isolated CI builds. When adding dependencies, update:
 - `go.mod` / `go.sum` — Go modules (`go mod tidy`)
 - `rpms.in.yaml` → regenerate `rpms.lock.yaml` — RPM packages
-- `artifacts.lock.yaml` — Go/Helm toolchain versions
+- `artifacts.lock.yaml` — external artifacts (Helm chart deps for caching-tester)
 - `tools.go` — build-time Go tool imports
 Forgetting lock files will break Konflux CI. See `HERMETIC-BUILDS.md`.
 

--- a/HERMETIC-BUILDS.md
+++ b/HERMETIC-BUILDS.md
@@ -25,7 +25,7 @@ The following files control which dependencies are available during hermetic bui
 
 | File | Purpose | Update Frequency |
 |------|---------|------------------|
-| `artifacts.lock.yaml` | Version locks for external artifacts (currently empty) | Rarely (only if external downloads needed) |
+| `artifacts.lock.yaml` | Version locks for external artifacts (Helm chart deps for caching-tester) | When `caching/Chart.lock` dependency versions change |
 | `rpms.in.yaml` | Declares required RPM packages (including go-toolset) | When adding system packages |
 | `rpms.lock.yaml` | Auto-generated transitive RPM dependencies | After changing `rpms.in.yaml` |
 | `go.mod` / `go.sum` | Go module dependencies | When adding/updating Go modules |
@@ -71,6 +71,18 @@ Important: Replace `<BASE_IMAGE_WITH_DIGEST>` with the exact image and digest fr
 
 **Step 3:** Commit both files.
 
+
+### Updating Helm Chart Dependencies (caching-tester)
+
+The caching-tester image vendors `cert-manager` and `trust-manager` chart archives so OpenShift e2e (`helm test`) does not fetch `charts.jetstack.io` at runtime. Those archives are prefetched by Hermeto's generic fetcher from `artifacts.lock.yaml`.
+
+When bumping chart dependency versions in `caching/Chart.yaml` / `caching/Chart.lock`:
+
+1. Download the matching chart archives from jetstack and record `sha256` checksums.
+2. Update the `download_url`, `checksum`, and `filename` entries in `artifacts.lock.yaml`.
+3. Keep filenames in the form `<chart>-<version>.tgz` (for example `cert-manager-v1.20.3.tgz`).
+
+`caching-tester` Pipelines-as-Code definitions must keep `{"type": "generic", "path": "."}` in `prefetch-input` for this to work under hermetic builds.
 
 ### Adding Build Tools
 
@@ -136,8 +148,9 @@ Manual intervention may be required for:
 
 - Adding new system packages (RPMs)
 - Adding new build-time tools
+- Bumping Helm chart dependencies used by caching-tester (`artifacts.lock.yaml` must stay aligned with `caching/Chart.lock`)
 
-Go and Helm versions are automatically updated by Mintmaker and Renovate respectively, so manual upgrades are rarely needed. When manual updates are necessary, they require modifying the appropriate lock files and, in the case of RPMs, regenerating the dependency lock file.
+Go and Helm CLI versions are automatically updated by Mintmaker and Renovate respectively, so manual upgrades are rarely needed. When manual updates are necessary, they require modifying the appropriate lock files and, in the case of RPMs, regenerating the dependency lock file.
 
 ## References
 

--- a/artifacts.lock.yaml
+++ b/artifacts.lock.yaml
@@ -1,5 +1,12 @@
 ---
 metadata:
   version: "1.0"
-artifacts: []
-
+artifacts:
+  # Helm chart dependencies for caching/ (pinned to caching/Chart.lock).
+  # Used by hermetic caching-tester builds so e2e tests do not fetch jetstack at runtime.
+  - download_url: "https://charts.jetstack.io/charts/cert-manager-v1.20.3.tgz"
+    checksum: "sha256:ef5d707f5afbb2c3ce9892f5ff3fca0dec6864db8830a1c454b3d4822c485843"
+    filename: "cert-manager-v1.20.3.tgz"
+  - download_url: "https://charts.jetstack.io/charts/trust-manager-v0.24.0.tgz"
+    checksum: "sha256:0de4bbef2d1a013bd4a91c6f59a9cb0273dda9a785e018a9a16e8f2b096af823"
+    filename: "trust-manager-v0.24.0.tgz"

--- a/test-entrypoint.sh
+++ b/test-entrypoint.sh
@@ -9,24 +9,18 @@ echo "Target namespace: ${TARGET_NAMESPACE:-caching}"
 echo "Squid service: ${SQUID_SERVICE:-squid.caching.svc.cluster.local:3128}"
 echo "Nginx service: ${NGINX_SERVICE:-nginx.caching.svc.cluster.local:8080}"
 
-# Build helm chart dependencies in a writable temp directory
-# The /app directory is read-only, so we need to copy the chart to /tmp
-echo "Building helm chart dependencies..."
-helm repo add jetstack https://charts.jetstack.io
-helm repo update
-
-# Copy chart to writable temp directory
+# The /app directory is read-only, so copy the chart to a writable temp directory.
+# Chart archives must already be vendored into the image (see test.Containerfile).
 CHART_DIR=$(mktemp -d)
 echo "Copying chart to temp directory: $CHART_DIR"
 cp -r /app/caching "$CHART_DIR/"
 
-# Build dependencies in the temp directory
-if ! helm dependency build "$CHART_DIR/caching"; then
-  echo "ERROR: Failed to build helm dependencies"
+if [ ! -d "$CHART_DIR/caching/charts" ] || [ -z "$(ls -A "$CHART_DIR/caching/charts" 2>/dev/null || true)" ]; then
+  echo "ERROR: Vendored helm chart dependencies missing under /app/caching/charts" >&2
+  echo "ERROR: Rebuild the caching-tester image with hermetic chart prefetch (artifacts.lock.yaml)." >&2
   exit 1
 fi
 
-# Change to the temp directory so tests use the chart with dependencies
 cd "$CHART_DIR"
 
 echo "✓ Helm dependencies ready at: $CHART_DIR/caching"
@@ -35,4 +29,3 @@ ls -la ./caching/charts/
 # Run the compiled test binary
 echo "Running tests..."
 exec /app/tests/e2e/e2e.test -ginkgo.v -ginkgo.label-filter="${LABEL_FILTER:-}"
-

--- a/test.Containerfile
+++ b/test.Containerfile
@@ -50,6 +50,24 @@ COPY caching/ ./caching/
 # Copy test entrypoint script
 COPY --chmod=0755 test-entrypoint.sh ./test-entrypoint.sh
 
+# Vendor helm chart dependencies into the image so in-cluster helm tests do not
+# need egress to charts.jetstack.io. Hermetic Konflux builds prefetch these via
+# artifacts.lock.yaml (generic fetcher); local non-hermetic builds fetch live.
+RUN mkdir -p caching/charts && \
+    if ls /cachi2/output/deps/generic/cert-manager-*.tgz >/dev/null 2>&1; then \
+      cp /cachi2/output/deps/generic/cert-manager-*.tgz \
+         /cachi2/output/deps/generic/trust-manager-*.tgz \
+         caching/charts/; \
+    elif [ -f /cachi2/cachi2.env ]; then \
+      echo "ERROR: hermetic build missing prefetched helm charts in /cachi2/output/deps/generic/" >&2; \
+      ls -la /cachi2/output/deps/generic/ >&2 || true; \
+      exit 1; \
+    else \
+      helm repo add jetstack https://charts.jetstack.io && \
+      helm dependency build ./caching; \
+    fi && \
+    ls -la caching/charts/
+
 # Compile tests, mirrord target, and nginx test backend server
 RUN if [ -f /cachi2/cachi2.env ]; then . /cachi2/cachi2.env; fi && \
     ginkgo build ./tests/e2e && \


### PR DESCRIPTION
Stop fetching charts.jetstack.io from the in-cluster helm test pod (DNS/egress flakes) by prefetching cert-manager and trust-manager via artifacts.lock.yaml and baking them into the tester image.

Assisted-by: Cursor

### Author's Checklist
- [ ] I understand the problem that the PR is trying to address.
- [ ] I understand the solution and its role and impact within the wider system.
- [ ] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
