### PR TITLE
ci: Retry jetstack Helm fetches on transient DNS/egress failures

### DIFF
--- a/.tekton/caching-openshift-e2e-tests.yaml
+++ b/.tekton/caching-openshift-e2e-tests.yaml
@@ -286,12 +286,47 @@ spec:
                   secret_args=""
                 fi
 
-                # Prepare Helm chart with cert-manager dependency
+                # Prepare Helm chart with cert-manager dependency.
+                # Retry transient DNS/egress failures talking to charts.jetstack.io.
+                retry_cmd() {
+                  local description="$1"
+                  shift
+                  local max_attempts=8
+                  local delay=2
+                  local max_delay=30
+                  local attempt=1
+                  local rc=0
+                  while (( attempt <= max_attempts )); do
+                    echo "→ ${description} (attempt ${attempt}/${max_attempts})"
+                    # Capture status immediately: after `if cmd; then ...; fi`, $? is 0 even on failure.
+                    "$@" && return 0
+                    rc=$?
+                    if (( attempt == max_attempts )); then
+                      break
+                    fi
+                    echo "WARNING: ${description} failed with exit ${rc}; retrying in ${delay}s..." >&2
+                    sleep "${delay}"
+                    delay=$(( delay * 2 ))
+                    if (( delay > max_delay )); then
+                      delay=${max_delay}
+                    fi
+                    attempt=$(( attempt + 1 ))
+                  done
+                  echo "ERROR: ${description} failed after ${max_attempts} attempts" >&2
+                  return "${rc}"
+                }
+
                 echo "Adding jetstack Helm repository..."
-                helm repo add jetstack https://charts.jetstack.io 2>/dev/null || true
-                helm repo update
+                retry_cmd "fetch jetstack chart index" \
+                  curl -fsS --connect-timeout 5 --retry 0 --max-time 60 \
+                  -o /dev/null "https://charts.jetstack.io/index.yaml"
+                retry_cmd "helm repo add jetstack" \
+                  helm repo add jetstack https://charts.jetstack.io --force-update
+                retry_cmd "helm repo update jetstack" \
+                  helm repo update jetstack
                 cd caching
-                helm dependency build
+                retry_cmd "helm dependency build" \
+                  helm dependency build
 
                 # Parse image references
                 # Handle both tag (repo:tag) and digest (repo@sha256:...) formats

--- a/test-entrypoint.sh
+++ b/test-entrypoint.sh
@@ -9,24 +9,55 @@ echo "Target namespace: ${TARGET_NAMESPACE:-caching}"
 echo "Squid service: ${SQUID_SERVICE:-squid.caching.svc.cluster.local:3128}"
 echo "Nginx service: ${NGINX_SERVICE:-nginx.caching.svc.cluster.local:8080}"
 
-# Build helm chart dependencies in a writable temp directory
-# The /app directory is read-only, so we need to copy the chart to /tmp
-echo "Building helm chart dependencies..."
-helm repo add jetstack https://charts.jetstack.io
-helm repo update
+# Retry wrapper for transient cluster DNS/egress failures (e.g. CoreDNS
+# "connection refused" when fetching charts.jetstack.io).
+retry_cmd() {
+  local description="$1"
+  shift
+  local max_attempts="${HELM_FETCH_MAX_ATTEMPTS:-8}"
+  local delay="${HELM_FETCH_INITIAL_DELAY_SEC:-2}"
+  local max_delay="${HELM_FETCH_MAX_DELAY_SEC:-30}"
+  local attempt=1
+  local rc=0
 
-# Copy chart to writable temp directory
+  while (( attempt <= max_attempts )); do
+    echo "→ ${description} (attempt ${attempt}/${max_attempts})"
+    # Capture status immediately: after `if cmd; then ...; fi`, $? is 0 even on failure.
+    "$@" && return 0
+    rc=$?
+    if (( attempt == max_attempts )); then
+      break
+    fi
+    echo "WARNING: ${description} failed with exit ${rc}; retrying in ${delay}s..." >&2
+    sleep "${delay}"
+    delay=$(( delay * 2 ))
+    if (( delay > max_delay )); then
+      delay=${max_delay}
+    fi
+    attempt=$(( attempt + 1 ))
+  done
+
+  echo "ERROR: ${description} failed after ${max_attempts} attempts" >&2
+  return "${rc}"
+}
+
+# The /app directory is read-only, so copy the chart to a writable temp directory.
 CHART_DIR=$(mktemp -d)
 echo "Copying chart to temp directory: $CHART_DIR"
 cp -r /app/caching "$CHART_DIR/"
 
-# Build dependencies in the temp directory
-if ! helm dependency build "$CHART_DIR/caching"; then
-  echo "ERROR: Failed to build helm dependencies"
-  exit 1
-fi
+echo "Building helm chart dependencies from charts.jetstack.io..."
+# Preflight reaches the chart index over HTTPS so DNS/egress flakes fail fast/clearly.
+retry_cmd "fetch jetstack chart index" \
+  curl -fsS --connect-timeout 5 --retry 0 --max-time 60 \
+  -o /dev/null "https://charts.jetstack.io/index.yaml"
+retry_cmd "helm repo add jetstack" \
+  helm repo add jetstack https://charts.jetstack.io --force-update
+retry_cmd "helm repo update jetstack" \
+  helm repo update jetstack
+retry_cmd "helm dependency build" \
+  helm dependency build "$CHART_DIR/caching"
 
-# Change to the temp directory so tests use the chart with dependencies
 cd "$CHART_DIR"
 
 echo "✓ Helm dependencies ready at: $CHART_DIR/caching"
@@ -35,4 +66,3 @@ ls -la ./caching/charts/
 # Run the compiled test binary
 echo "Running tests..."
 exec /app/tests/e2e/e2e.test -ginkgo.v -ginkgo.label-filter="${LABEL_FILTER:-}"
-


### PR DESCRIPTION
OpenShift e2e can fail when the caching-test pod cannot reach charts.jetstack.io due to brief CoreDNS errors; retry the chart index/repo/dependency steps in the test entrypoint and Tekton deploy.

Assisted-by: Cursor

### Author's Checklist
- [ ] I understand the problem that the PR is trying to address.
- [ ] I understand the solution and its role and impact within the wider system.
- [ ] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
