### PR TITLE
docs: Update NOTES.txt to show only enabled components with correct namespaces

### DIFF
--- a/caching/templates/NOTES.txt
+++ b/caching/templates/NOTES.txt
@@ -1,18 +1,36 @@
 {{- $squidNamespace := include "caching.squid.namespace" . -}}
-Your Squid proxy has been deployed to the '{{ $squidNamespace }}' namespace.
+{{- $nginxNamespace := include "caching.nginx.namespace" . -}}
+{{- if .Values.squid.enabled }}
+=== Squid Forward Proxy ===
+
+Deployed to the '{{ $squidNamespace }}' namespace.
 
 To connect from other pods within the Kubernetes cluster:
 - From inside the '{{ $squidNamespace }}' namespace:
   http://{{ .Values.squid.name }}:{{ .Values.service.port }}
 
-- From any namespace:
+- From any namespace (FQDN):
   http://{{ include "caching.squid.fqdn" . }}:{{ .Values.service.port }}
-
 
 For local testing, you can forward the service port to your machine:
 1. Get the pod name:
    export POD_NAME=$(kubectl get pods --namespace {{ $squidNamespace }} -l "app.kubernetes.io/name={{ .Values.squid.name }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
 
 2. Forward the port:
-   echo "Forwarding Squid proxy to http://127.0.0.1:3128"
-   kubectl --namespace {{ $squidNamespace }} port-forward $POD_NAME 3128:3128
+   echo "Forwarding Squid proxy to http://127.0.0.1:{{ .Values.service.port }}"
+   kubectl --namespace {{ $squidNamespace }} port-forward $POD_NAME {{ .Values.service.port }}:{{ .Values.service.port }}
+{{- end }}
+{{- if .Values.nginx.enabled }}
+
+=== Nginx Reverse Proxy ===
+
+Deployed to the '{{ $nginxNamespace }}' namespace.
+
+To connect from other pods within the Kubernetes cluster:
+- From inside the '{{ $nginxNamespace }}' namespace:
+  {{ if .Values.nginx.tls.enabled }}https{{ else }}http{{ end }}://{{ .Values.nginx.name }}:{{ .Values.nginx.service.port }}
+
+- From any namespace (FQDN):
+  {{ if .Values.nginx.tls.enabled }}https{{ else }}http{{ end }}://{{ include "caching.nginx.fqdn" . }}:{{ .Values.nginx.service.port }}
+
+{{- end }}


### PR DESCRIPTION
Add conditional rendering for squid and nginx sections, use namespace helpers for component-specific namespaces, display both short name and FQDN service access, and templatize port references.

Jira-url: https://redhat.atlassian.net/browse/KFLUXVNGD-1150
Assisted-by: Claude Opus 4.6

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [x] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
