### PR TITLE
feat(KFLUXVNGD-1174): add generic nginx subFilters rewrites

### DIFF
--- a/caching/templates/nginx-configmap.yaml
+++ b/caching/templates/nginx-configmap.yaml
@@ -137,6 +137,47 @@ data:
                 access_log off;
             }
 
+            {{- range .Values.nginx.subFilters }}
+            # SubFilter location: {{ .location }}
+            location ~ {{ .location }} {
+                proxy_pass $upstream_url;
+                proxy_set_header Host $upstream_host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
+
+                {{- if $.Values.nginx.auth.enabled }}
+                proxy_set_header Authorization "__AUTH_HEADER__";
+                {{- end }}
+
+                {{- /* Default disableCompression to true so sub_filter can see the body */}}
+                {{- if or (not (hasKey . "disableCompression")) .disableCompression }}
+                proxy_set_header Accept-Encoding "";
+                {{- end }}
+
+                {{- range .filters }}
+                sub_filter '{{ .string }}' '{{ .replacement }}';
+                {{- end }}
+
+                {{- if .types }}
+                sub_filter_types {{ join " " .types }};
+                {{- else }}
+                sub_filter_types application/json;
+                {{- end }}
+
+                {{- if kindIs "bool" .once }}
+                sub_filter_once {{ if .once }}on{{ else }}off{{ end }};
+                {{- else }}
+                sub_filter_once on;
+                {{- end }}
+
+                proxy_no_cache 1;
+                proxy_cache_bypass 1;
+
+                add_header X-Cache-Status "BYPASS" always;
+            }
+            {{- end }}
+
             {{- range .Values.nginx.cache.allowList }}
             # AllowList location matching pattern: {{ . }}
             location ~ {{ . }} {

--- a/caching/values.schema.json
+++ b/caching/values.schema.json
@@ -724,6 +724,61 @@
           "required": ["enabled"],
           "additionalProperties": false
         },
+        "subFilters": {
+          "type": "array",
+          "description": "ngx_http_sub_module response rewrites. Each entry renders a location ~ block with sub_filter directives. Empty means no rewrite locations. Location patterns must not overlap nginx.cache.allowList; subFilters wins on overlap.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "location": {
+                "type": "string",
+                "pattern": "^[^{}'\";\\n\\r#]+$",
+                "description": "Regex used in 'location ~ <location>'. Must not contain braces, quotes, semicolons, newlines, or #. Must not overlap nginx.cache.allowList patterns."
+              },
+              "filters": {
+                "type": "array",
+                "description": "sub_filter string replacement pairs",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "string": {
+                      "type": "string",
+                      "pattern": "^[^'\\n\\r;]+$",
+                      "description": "Non-empty string to search for in the response body. Must not contain single quotes, newlines, or semicolons."
+                    },
+                    "replacement": {
+                      "type": "string",
+                      "pattern": "^[^'\\n\\r;]*$",
+                      "description": "Replacement string. Must not contain single quotes, newlines, or semicolons."
+                    }
+                  },
+                  "required": ["string", "replacement"],
+                  "additionalProperties": false
+                },
+                "minItems": 1
+              },
+              "once": {
+                "type": "boolean",
+                "description": "sub_filter_once; defaults to true when omitted"
+              },
+              "types": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "pattern": "^[a-zA-Z0-9.+-]+/[a-zA-Z0-9.+-]+$",
+                  "description": "MIME type for sub_filter_types (e.g. application/json)."
+                },
+                "description": "sub_filter_types MIME types; defaults to application/json when omitted"
+              },
+              "disableCompression": {
+                "type": "boolean",
+                "description": "Clear Accept-Encoding so sub_filter sees an uncompressed body; defaults to true when omitted"
+              }
+            },
+            "required": ["location", "filters"],
+            "additionalProperties": false
+          }
+        },
         "cache": {
           "type": "object",
           "properties": {

--- a/caching/values.yaml
+++ b/caching/values.yaml
@@ -485,6 +485,16 @@ nginx:
     # The secret must have a key named "authorization"
     secretName: ""
 
+  # Response body rewrites (sub_filter). Empty = disabled.
+  # See docs/redirect-caching-architecture.md#response-body-rewrites-nginxsubfilters.
+  # Example:
+  # subFilters:
+  #   - location: '^/repository/[^/]+/config\.json$'
+  #     filters:
+  #       - string: '"auth-required":true'
+  #         replacement: '"auth-required":false'
+  subFilters: []
+
   # Cache configuration
   cache:
     # List of regex patterns for paths to cache

--- a/docs/redirect-caching-architecture.md
+++ b/docs/redirect-caching-architecture.md
@@ -119,6 +119,24 @@ sequenceDiagram
 | `nginx.cache.size` | `1024` MiB | `1024` MiB | Maximum disk cache size |
 | `inactive` | `7d` (hardcoded) | `7d` | Evict items not accessed within this period |
 | `nginx.cache.allowList` | `[]` | configured | URL patterns routed through redirect caching |
+| `nginx.subFilters` | `[]` | configured | Response body rewrites; see [below](#response-body-rewrites-nginxsubfilters) |
 
 > **Note:** Even with a 30-day TTL, items not accessed for 7 days are evicted due to the
 > hardcoded `inactive=7d` setting in the nginx ConfigMap.
+
+## Response body rewrites (`nginx.subFilters`)
+
+The nginx proxy can rewrite response bodies for specific URL patterns via `nginx.subFilters`
+in Helm values. Chart defaults leave this disabled (`subFilters: []`); operators configure
+paths and replacement strings at deploy time.
+
+Each entry renders a dedicated `location ~` block that proxies to the upstream (with optional
+auth header injection), applies `sub_filter` string replacements on the response body, and
+bypasses the redirect cache (`proxy_no_cache` / `proxy_cache_bypass`).
+
+**Precedence:** `subFilters` locations are declared before `allowList` locations in nginx.conf.
+If a URL matches both, the `subFilters` block wins. Avoid overlapping patterns.
+
+`sub_filter` performs exact string replacement (not JSON-aware). Filter strings must not
+contain single quotes, newlines, or semicolons (enforced by `values.schema.json`). See
+`caching/values.yaml` for an example entry.

--- a/tests/e2e/nginx_proxy_test.go
+++ b/tests/e2e/nginx_proxy_test.go
@@ -1,6 +1,7 @@
 package e2e_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -29,6 +30,17 @@ var _ = Describe("Nginx Proxy Caching Tests", Label("nginx"), Ordered, Serial, f
 				Auth: &testhelpers.NginxAuthValues{
 					Enabled:    true,
 					SecretName: authSecretName,
+				},
+				SubFilters: []testhelpers.NginxSubFilterValues{
+					{
+						Location: `^/repository/[^/]+/config\.json$`,
+						Filters: []testhelpers.NginxSubFilterPair{
+							{
+								String:      `"auth-required":true`,
+								Replacement: `"auth-required":false`,
+							},
+						},
+					},
 				},
 				Cache: &testhelpers.NginxCacheValues{
 					AllowList: []string{"^/content/"},
@@ -102,5 +114,39 @@ var _ = Describe("Nginx Proxy Caching Tests", Label("nginx"), Ordered, Serial, f
 		cacheStatus := resp.Header.Get("X-Cache-Status")
 		Expect(cacheStatus).To(Equal("BYPASS"),
 			"Requests to non-matching paths should be BYPASS")
+	})
+
+	It("should apply configured sub_filter rewrites to matching responses", func() {
+		reqURL := testhelpers.GetNginxURL() + "/repository/cargo-proxy/config.json"
+		resp, err := client.Get(reqURL)
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).NotTo(HaveOccurred())
+
+		var cfg map[string]interface{}
+		Expect(json.Unmarshal(body, &cfg)).To(Succeed())
+		Expect(cfg["auth-required"]).To(Equal(false),
+			"Proxy should apply configured sub_filter; body=%s", string(body))
+	})
+
+	It("should not rewrite responses outside subFilters locations", func() {
+		reqURL := testhelpers.GetNginxURL() + "/content/passthrough-test"
+		resp, err := client.Get(reqURL)
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(string(body)).To(ContainSubstring(`"message"`))
+
+		var cfg map[string]interface{}
+		Expect(json.Unmarshal(body, &cfg)).To(Succeed())
+		Expect(cfg["auth-required"]).To(Equal(true),
+			"Responses outside subFilters locations must pass through unmodified; body=%s", string(body))
 	})
 })

--- a/tests/helm/nginx_template_test.go
+++ b/tests/helm/nginx_template_test.go
@@ -307,8 +307,67 @@ var _ = Describe("Helm Template Nginx Configuration", func() {
 
 			configMap := extractNginxConfigMapSection(output)
 
-			// Auth header should appear in both cached location and default location
-			Expect(strings.Count(configMap, `proxy_set_header Authorization "__AUTH_HEADER__"`)).To(Equal(2), "Should have auth header in both locations")
+			Expect(strings.Count(configMap, `proxy_set_header Authorization "__AUTH_HEADER__"`)).To(Equal(2), "Should have auth header in allowList and default locations")
+		})
+
+		It("should not render sub_filter locations when subFilters is empty", func() {
+			output, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{
+				Nginx: &testhelpers.NginxValues{
+					Enabled: true,
+					Upstream: &testhelpers.NginxUpstreamValues{
+						URL: "http://backend:8080",
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			configMap := extractNginxConfigMapSection(output)
+
+			Expect(configMap).NotTo(ContainSubstring("sub_filter"), "Should not render sub_filter without subFilters values")
+		})
+
+		It("should render sub_filter locations from nginx.subFilters values", func() {
+			once := true
+			disableCompression := true
+			output, err := testhelpers.RenderHelmTemplate(chartPath, testhelpers.SquidHelmValues{
+				Nginx: &testhelpers.NginxValues{
+					Enabled: true,
+					Upstream: &testhelpers.NginxUpstreamValues{
+						URL: "http://backend:8080",
+					},
+					Auth: &testhelpers.NginxAuthValues{
+						Enabled:    true,
+						SecretName: "my-secret",
+					},
+					SubFilters: []testhelpers.NginxSubFilterValues{
+						{
+							Location: `^/repository/[^/]+/config\.json$`,
+							Filters: []testhelpers.NginxSubFilterPair{
+								{
+									String:      `"auth-required":true`,
+									Replacement: `"auth-required":false`,
+								},
+							},
+							Once:               &once,
+							DisableCompression: &disableCompression,
+						},
+					},
+					Cache: &testhelpers.NginxCacheValues{
+						AllowList: []string{`^/api/.*`},
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			configMap := extractNginxConfigMapSection(output)
+
+			Expect(configMap).To(ContainSubstring(`location ~ ^/repository/[^/]+/config\.json$`), "Should render configured rewrite location")
+			Expect(configMap).To(ContainSubstring(`sub_filter '"auth-required":true' '"auth-required":false'`), "Should render configured sub_filter pair")
+			Expect(configMap).To(ContainSubstring("sub_filter_types application/json"), "Should default sub_filter_types to application/json when omitted")
+			Expect(configMap).To(ContainSubstring("sub_filter_once on"), "Should render sub_filter_once on")
+			Expect(configMap).To(ContainSubstring(`proxy_set_header Accept-Encoding ""`), "Should disable upstream compression by default")
+			Expect(strings.Count(configMap, `proxy_set_header Authorization "__AUTH_HEADER__"`)).To(Equal(3), "Should have auth header in subFilter, allowList, and default locations")
+			Expect(configMap).To(ContainSubstring(`add_header X-Cache-Status "BYPASS" always`), "subFilter locations should report BYPASS cache status")
 		})
 
 		It("should render @handle_redirect when allowList has entries", func() {

--- a/tests/nginx-test-backend/main.go
+++ b/tests/nginx-test-backend/main.go
@@ -88,12 +88,51 @@ func main() {
 		w.Header().Set("Content-Type", "application/json")
 
 		response := map[string]interface{}{
-			"message":     "nginx-test-backend",
-			"request_id":  float64(count),
-			"timestamp":   float64(time.Now().Unix()),
-			"server_hits": float64(count),
+			"message":       "nginx-test-backend",
+			"auth-required": true,
+			"request_id":    float64(count),
+			"timestamp":     float64(time.Now().Unix()),
+			"server_hits":   float64(count),
 		}
 		json.NewEncoder(w).Encode(response)
+	})
+
+	// Sample registry config.json for testing ngx_http_sub_module rewrites.
+	// Path: /repository/<repo-name>/config.json
+	mux.HandleFunc("GET /repository/{repo}/config.json", func(w http.ResponseWriter, r *http.Request) {
+		if !checkAuth(w, r) {
+			return
+		}
+		if checkOverrideStatus(w, r) {
+			return
+		}
+
+		repo := r.PathValue("repo")
+		if repo == "" {
+			http.NotFound(w, r)
+			return
+		}
+
+		// Compact JSON matching common registry index config shape:
+		// {"dl":"...","api":"...","auth-required":true}
+		cfg := struct {
+			DL           string `json:"dl"`
+			API          string `json:"api"`
+			AuthRequired bool   `json:"auth-required"`
+		}{
+			DL:           fmt.Sprintf("http://nexus-test/repository/%s/crates", repo),
+			API:          fmt.Sprintf("http://nexus-test/repository/%s/", repo),
+			AuthRequired: true,
+		}
+		body, err := json.Marshal(cfg)
+		if err != nil {
+			http.Error(w, "failed to encode config.json", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
 	})
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/tests/testhelpers/nginx_helpers.go
+++ b/tests/testhelpers/nginx_helpers.go
@@ -18,17 +18,33 @@ import (
 // NginxValues holds Helm values for nginx configuration
 type NginxValues struct {
 	// Enabled must NOT have omitempty since we need to explicitly set false to disable
-	Enabled      bool                  `json:"enabled"`
-	Name         string                `json:"name,omitempty"`
-	Namespace    string                `json:"namespace,omitempty"`
-	ReplicaCount int                   `json:"replicaCount,omitempty"`
-	TLS          *NginxTLSValues       `json:"tls,omitempty"`
-	Upstream     *NginxUpstreamValues  `json:"upstream,omitempty"`
-	Auth         *NginxAuthValues      `json:"auth,omitempty"`
-	Cache        *NginxCacheValues     `json:"cache,omitempty"`
-	Service      *NginxServiceValues   `json:"service,omitempty"`
-	Affinity     json.RawMessage       `json:"affinity,omitempty"`
-	Exporter     *NginxExporterValues  `json:"exporter,omitempty"`
+	Enabled      bool                   `json:"enabled"`
+	Name         string                 `json:"name,omitempty"`
+	Namespace    string                 `json:"namespace,omitempty"`
+	ReplicaCount int                    `json:"replicaCount,omitempty"`
+	TLS          *NginxTLSValues        `json:"tls,omitempty"`
+	Upstream     *NginxUpstreamValues   `json:"upstream,omitempty"`
+	Auth         *NginxAuthValues       `json:"auth,omitempty"`
+	SubFilters   []NginxSubFilterValues `json:"subFilters,omitempty"`
+	Cache        *NginxCacheValues      `json:"cache,omitempty"`
+	Service      *NginxServiceValues    `json:"service,omitempty"`
+	Affinity     json.RawMessage        `json:"affinity,omitempty"`
+	Exporter     *NginxExporterValues   `json:"exporter,omitempty"`
+}
+
+// NginxSubFilterValues configures an ngx_http_sub_module rewrite location.
+type NginxSubFilterValues struct {
+	Location           string               `json:"location"`
+	Filters            []NginxSubFilterPair `json:"filters"`
+	Once               *bool                `json:"once,omitempty"`
+	Types              []string             `json:"types,omitempty"`
+	DisableCompression *bool                `json:"disableCompression,omitempty"`
+}
+
+// NginxSubFilterPair is one sub_filter string/replacement pair.
+type NginxSubFilterPair struct {
+	String      string `json:"string"`
+	Replacement string `json:"replacement"`
 }
 
 // NginxExporterValues holds access-log-exporter sidecar configuration


### PR DESCRIPTION
Add a deployment-configurable `nginx.subFilters` mechanism that renders scoped `sub_filter` rewrite locations in nginx while keeping chart defaults proxy-agnostic. This enables cargo `config.json` auth-required rewriting via deployment values without hardcoding cargo behavior in this chart.


Assisted-by: Auto (via Cursor)

### Author's Checklist
- [ ] I understand the problem that the PR is trying to address.
- [ ] I understand the solution and its role and impact within the wider system.
- [ ] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
