### PR TITLE
fix(KFLUXVNGD-1272): Use rootful Podman and direct ctr import for Kind in CI

### DIFF
--- a/.github/workflows/devcontainer-ci.yml
+++ b/.github/workflows/devcontainer-ci.yml
@@ -38,10 +38,17 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y podman
 
-    - name: Start podman service
+    - name: Start podman services
       run: |
-        # Start user podman service for socket mounting
+        # Two sockets: rootless for the devcontainer lifecycle (--userns=keep-id)
+        # and rootful for Kind, which avoids the rootless cgroup delegation check.
+        # The rootful socket is safe here because GitHub Actions runners are ephemeral.
+        # TODO: revert to rootless once Kind supports running without Delegate=yes
         systemctl --user start podman.socket
+        sudo systemctl start podman.socket
+        test -S /run/podman/podman.sock || { echo "::error::Rootful podman socket not found at /run/podman/podman.sock"; exit 1; }
+        sudo chgrp "$(id -g)" /run/podman/podman.sock
+        sudo chmod 660 /run/podman/podman.sock
 
     - name: Initialize devcontainer environment
       run: |
@@ -75,7 +82,7 @@ jobs:
           --security-opt=label=disable \
           --privileged \
           -v $PWD:/workspaces/caching \
-          -v ${XDG_RUNTIME_DIR}/podman/podman.sock:/var/run/podman.sock:Z \
+          -v /run/podman/podman.sock:/var/run/podman.sock:Z \
           -e CONTAINER_HOST=unix:///var/run/podman.sock \
           devcontainer:latest \
           sleep infinity

--- a/internal/kind.go
+++ b/internal/kind.go
@@ -38,6 +38,20 @@ func ExportKubeconfig(name string) error {
 	return sh.Run("kind", "export", "kubeconfig", "--name", name)
 }
 
+// LoadImage loads a container image into the Kind cluster's control-plane node
+func LoadImage(clusterName, imageTag string) error {
+	nodeName := clusterName + "-control-plane" // single-node cluster
+	q := func(s string) string { return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'" }
+	cmd := fmt.Sprintf(
+		"set -o pipefail; podman save --format docker-archive %s | podman exec -i %s ctr --namespace=k8s.io images import --digests -",
+		q(imageTag), q(nodeName),
+	)
+	if err := sh.Run("bash", "-c", cmd); err != nil {
+		return fmt.Errorf("loading image %s into cluster %s: %w", imageTag, clusterName, err)
+	}
+	return nil
+}
+
 // GetClusterInfo gets cluster info for the given cluster
 func GetClusterInfo(name string) (string, error) {
 	return sh.Output("kubectl", "cluster-info", "--context", "kind-"+name)

--- a/magefile.go
+++ b/magefile.go
@@ -344,17 +344,14 @@ func (Build) LoadAccessLogExporter() error {
 
 	fmt.Println("📦 Loading access-log-exporter image into kind cluster...")
 
-	// Load image into kind cluster using process substitution
 	fmt.Printf("📤 Loading image into kind cluster '%s'...\n", clusterName)
-	err := sh.Run("bash", "-c", fmt.Sprintf("kind load image-archive --name %s <(podman save %s)", clusterName, accessLogExporterImageTag))
-	if err != nil {
-		return fmt.Errorf("failed to load access-log-exporter image into kind cluster: %w", err)
+	if err := internal.LoadImage(clusterName, accessLogExporterImageTag); err != nil {
+		return fmt.Errorf("failed to load access-log-exporter image: %w", err)
 	}
 
 	// Verify image is available in cluster
 	fmt.Printf("🔍 Verifying image is available in cluster...\n")
-	err = internal.GetNodeStatus(clusterName)
-	if err != nil {
+	if err := internal.GetNodeStatus(clusterName); err != nil {
 		return fmt.Errorf("failed to connect to cluster for verification: %w", err)
 	}
 
@@ -369,17 +366,14 @@ func (Build) LoadSquid() error {
 
 	fmt.Println("📦 Loading Squid image into kind cluster...")
 
-	// Load image into kind cluster using process substitution
 	fmt.Printf("📤 Loading image into kind cluster '%s'...\n", clusterName)
-	err := sh.Run("bash", "-c", fmt.Sprintf("kind load image-archive --name %s <(podman save %s)", clusterName, squidImageTag))
-	if err != nil {
-		return fmt.Errorf("failed to load image into kind cluster: %w", err)
+	if err := internal.LoadImage(clusterName, squidImageTag); err != nil {
+		return fmt.Errorf("failed to load squid image: %w", err)
 	}
 
 	// Verify image is available in cluster
 	fmt.Printf("🔍 Verifying image is available in cluster...\n")
-	err = internal.GetNodeStatus(clusterName)
-	if err != nil {
+	if err := internal.GetNodeStatus(clusterName); err != nil {
 		return fmt.Errorf("failed to connect to cluster for verification: %w", err)
 	}
 
@@ -418,10 +412,8 @@ func (Build) LoadTestImage() error {
 
 	fmt.Println("📦 Loading test image into kind cluster...")
 
-	// Load image into kind cluster using process substitution
 	fmt.Printf("📤 Loading image into kind cluster '%s'...\n", clusterName)
-	err := sh.Run("bash", "-c", fmt.Sprintf("kind load image-archive --name %s <(podman save %s)", clusterName, testImageTag))
-	if err != nil {
+	if err := internal.LoadImage(clusterName, testImageTag); err != nil {
 		return fmt.Errorf("failed to load test image into kind cluster: %w", err)
 	}
 

--- a/skills/kind-cluster-setup/SKILL.md
+++ b/skills/kind-cluster-setup/SKILL.md
@@ -5,6 +5,6 @@ description: Gotchas when setting up or tearing down the local kind cluster
 
 # Managing Kind Clusters
 
-- `kind load` calls `podman save` under the hood -- if it hangs, check the Podman socket (`systemctl --user status podman.socket`)
+- Image loading uses `podman save | podman exec <node> ctr images import` to bypass Kind v0.29.0's broken `--all-platforms` flag -- if it hangs, check the Podman socket (`systemctl --user status podman.socket`)
 - `mage clean` also deletes squid and test images, not just the cluster -- re-running `mage all` afterwards rebuilds from scratch
 - `mage kind:upClean` destroys deployed workloads and persistent volumes -- use `mage kind:up` if you only need to re-export kubeconfig


### PR DESCRIPTION
The ubuntu-latest runner's Podman/systemd update broke Kind cluster creation because rootless Podman lacks cgroup delegation on CI runners, and Kind v0.29.0's --all-platforms flag breaks single-platform image loading. This PR switches CI to a rootful Podman socket and imports images directly via ctr to bypass both issues.

Jira-Url: https://redhat.atlassian.net/browse/KFLUXVNGD-1272
Assisted-By: Claude Code

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [ ] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
