### PR TITLE
fix: Disable cancel-in-progress on caching-helm push pipeline

### DIFF
--- a/.tekton/caching-helm-push.yaml
+++ b/.tekton/caching-helm-push.yaml
@@ -5,7 +5,7 @@ metadata:
     build.appstudio.openshift.io/repo: https://github.com/konflux-ci/caching?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: "{{revision}}"
     build.appstudio.redhat.com/target_branch: "{{target_branch}}"
-    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
   creationTimestamp: null


### PR DESCRIPTION
caching-helm-push had cancel-in-progress: "true" while all other component push pipelines had "false". When rapid pushes occurred, the previous caching-helm build was canceled while squid/exporter/tester builds continued, producing snapshots with mismatched component revisions. The snapshot-consistency-test correctly blocked these, but no consistent snapshot could be created — breaking all releases since July 20.

Co-Authored-By: Claude Opus 4.6

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [ ] I opted for automation and automated tests over documenting multiple steps.

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
