### PR TITLE
Fix rootless podman

### DIFF
--- a/.github/workflows/devcontainer-ci.yml
+++ b/.github/workflows/devcontainer-ci.yml
@@ -38,17 +38,10 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y podman
 
-    - name: Start podman services
+    - name: Start podman service
       run: |
-        # Two sockets: rootless for the devcontainer lifecycle (--userns=keep-id)
-        # and rootful for Kind, which avoids the rootless cgroup delegation check.
-        # The rootful socket is safe here because GitHub Actions runners are ephemeral.
-        # TODO: revert to rootless once Kind supports running without Delegate=yes
+        # Start user podman service for socket mounting
         systemctl --user start podman.socket
-        sudo systemctl start podman.socket
-        test -S /run/podman/podman.sock || { echo "::error::Rootful podman socket not found at /run/podman/podman.sock"; exit 1; }
-        sudo chgrp "$(id -g)" /run/podman/podman.sock
-        sudo chmod 660 /run/podman/podman.sock
 
     - name: Initialize devcontainer environment
       run: |
@@ -82,7 +75,7 @@ jobs:
           --security-opt=label=disable \
           --privileged \
           -v $PWD:/workspaces/caching \
-          -v /run/podman/podman.sock:/var/run/podman.sock:Z \
+          -v ${XDG_RUNTIME_DIR}/podman/podman.sock:/var/run/podman.sock:Z \
           -e CONTAINER_HOST=unix:///var/run/podman.sock \
           devcontainer:latest \
           sleep infinity

--- a/.github/workflows/devcontainer-ci.yml
+++ b/.github/workflows/devcontainer-ci.yml
@@ -38,10 +38,22 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y podman
 
-    - name: Start podman service
+    - name: Configure rootless podman for cgroup delegation
       run: |
-        # Start user podman service for socket mounting
-        systemctl --user start podman.socket
+        # kind queries `podman info` over the socket; podman reports the cgroup
+        # controllers present in the serving daemon's own cgroup, and kind
+        # requires the cpu controller there. Declaring Delegate=yes on the user
+        # podman service makes systemd enable the delegated controllers
+        # (including cpu) in the daemon's cgroup.
+        mkdir -p ~/.config/systemd/user/podman.service.d
+        printf '[Service]\nDelegate=yes\n' > ~/.config/systemd/user/podman.service.d/delegate.conf
+        systemctl --user daemon-reload
+
+    - name: Start podman services
+      run: |
+        # podman.socket exposes the socket the devcontainer mounts; podman.service
+        # is the daemon kind talks to.
+        systemctl --user start podman.socket podman.service
 
     - name: Initialize devcontainer environment
       run: |

--- a/internal/kind.go
+++ b/internal/kind.go
@@ -38,20 +38,6 @@ func ExportKubeconfig(name string) error {
 	return sh.Run("kind", "export", "kubeconfig", "--name", name)
 }
 
-// LoadImage loads a container image into the Kind cluster's control-plane node
-func LoadImage(clusterName, imageTag string) error {
-	nodeName := clusterName + "-control-plane" // single-node cluster
-	q := func(s string) string { return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'" }
-	cmd := fmt.Sprintf(
-		"set -o pipefail; podman save --format docker-archive %s | podman exec -i %s ctr --namespace=k8s.io images import --digests -",
-		q(imageTag), q(nodeName),
-	)
-	if err := sh.Run("bash", "-c", cmd); err != nil {
-		return fmt.Errorf("loading image %s into cluster %s: %w", imageTag, clusterName, err)
-	}
-	return nil
-}
-
 // GetClusterInfo gets cluster info for the given cluster
 func GetClusterInfo(name string) (string, error) {
 	return sh.Output("kubectl", "cluster-info", "--context", "kind-"+name)

--- a/magefile.go
+++ b/magefile.go
@@ -344,14 +344,17 @@ func (Build) LoadAccessLogExporter() error {
 
 	fmt.Println("📦 Loading access-log-exporter image into kind cluster...")
 
+	// Load image into kind cluster using process substitution
 	fmt.Printf("📤 Loading image into kind cluster '%s'...\n", clusterName)
-	if err := internal.LoadImage(clusterName, accessLogExporterImageTag); err != nil {
-		return fmt.Errorf("failed to load access-log-exporter image: %w", err)
+	err := sh.Run("bash", "-c", fmt.Sprintf("kind load image-archive --name %s <(podman save %s)", clusterName, accessLogExporterImageTag))
+	if err != nil {
+		return fmt.Errorf("failed to load access-log-exporter image into kind cluster: %w", err)
 	}
 
 	// Verify image is available in cluster
 	fmt.Printf("🔍 Verifying image is available in cluster...\n")
-	if err := internal.GetNodeStatus(clusterName); err != nil {
+	err = internal.GetNodeStatus(clusterName)
+	if err != nil {
 		return fmt.Errorf("failed to connect to cluster for verification: %w", err)
 	}
 
@@ -366,14 +369,17 @@ func (Build) LoadSquid() error {
 
 	fmt.Println("📦 Loading Squid image into kind cluster...")
 
+	// Load image into kind cluster using process substitution
 	fmt.Printf("📤 Loading image into kind cluster '%s'...\n", clusterName)
-	if err := internal.LoadImage(clusterName, squidImageTag); err != nil {
-		return fmt.Errorf("failed to load squid image: %w", err)
+	err := sh.Run("bash", "-c", fmt.Sprintf("kind load image-archive --name %s <(podman save %s)", clusterName, squidImageTag))
+	if err != nil {
+		return fmt.Errorf("failed to load image into kind cluster: %w", err)
 	}
 
 	// Verify image is available in cluster
 	fmt.Printf("🔍 Verifying image is available in cluster...\n")
-	if err := internal.GetNodeStatus(clusterName); err != nil {
+	err = internal.GetNodeStatus(clusterName)
+	if err != nil {
 		return fmt.Errorf("failed to connect to cluster for verification: %w", err)
 	}
 
@@ -412,8 +418,10 @@ func (Build) LoadTestImage() error {
 
 	fmt.Println("📦 Loading test image into kind cluster...")
 
+	// Load image into kind cluster using process substitution
 	fmt.Printf("📤 Loading image into kind cluster '%s'...\n", clusterName)
-	if err := internal.LoadImage(clusterName, testImageTag); err != nil {
+	err := sh.Run("bash", "-c", fmt.Sprintf("kind load image-archive --name %s <(podman save %s)", clusterName, testImageTag))
+	if err != nil {
 		return fmt.Errorf("failed to load test image into kind cluster: %w", err)
 	}
 

--- a/skills/kind-cluster-setup/SKILL.md
+++ b/skills/kind-cluster-setup/SKILL.md
@@ -5,6 +5,6 @@ description: Gotchas when setting up or tearing down the local kind cluster
 
 # Managing Kind Clusters
 
-- Image loading uses `podman save | podman exec <node> ctr images import` to bypass Kind v0.29.0's broken `--all-platforms` flag -- if it hangs, check the Podman socket (`systemctl --user status podman.socket`)
+- `kind load` calls `podman save` under the hood -- if it hangs, check the Podman socket (`systemctl --user status podman.socket`)
 - `mage clean` also deletes squid and test images, not just the cluster -- re-running `mage all` afterwards rebuilds from scratch
 - `mage kind:upClean` destroys deployed workloads and persistent volumes -- use `mage kind:up` if you only need to re-export kubeconfig


### PR DESCRIPTION
This reverts the changes from #1064 and uses a simpler approach to enable cgroup delegation. No rootful podman or kind image load workarounds required.

### Author's Checklist
- [x] I understand the problem that the PR is trying to address.
- [x] I understand the solution and its role and impact within the wider system.
- [ ] ~I opted for automation and automated tests over documenting multiple steps.~

### Reviewer's Guide
- [ ] What is the PR trying to solve?
- [ ] Does the solution make sense?
- [ ] How does this affect the wider system?
- [ ] Is it being tested properly?
- [ ] Does it keep documentation concise and maintainable?
